### PR TITLE
Reset integrator

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -332,7 +332,7 @@ export default function App() {
       case 'multiplier':
         break;
       case 'integrator':
-        nodeData = { ...nodeData, initial_value: '' };
+        nodeData = { ...nodeData, initial_value: '', reset_times: '' };
         break;
       case 'adder':
         break;


### PR DESCRIPTION
Closes #58 

I simply added an extra data entry for Integrator `reset_times` which is optional. It can take a single value (float, int), a list of values, or even an interpreted python expression including numpy arrays.

<img width="1377" height="657" alt="image" src="https://github.com/user-attachments/assets/62124f7d-161e-4e1e-9566-d73dc4d573e4" />

### Single value `12.5`:
<img width="1233" height="673" alt="image" src="https://github.com/user-attachments/assets/3bf452ad-48ab-421f-a4c8-e2f66ecad717" />

### Two values `[12, 5]`:
<img width="1233" height="673" alt="image" src="https://github.com/user-attachments/assets/7caac1ec-1289-47a5-ad17-24b8a7f9ec33" />


### Numpy linspace: `np.linspace(0, 40, 18)`

<img width="1233" height="673" alt="image" src="https://github.com/user-attachments/assets/5648ce14-a1e7-4b0b-b699-c9b1b79e254d" />

### Numpy geomspace: `np.geomspace(1, 50, num=8)`
<img width="1233" height="673" alt="image" src="https://github.com/user-attachments/assets/8f9c30c7-93c1-45a7-b191-071c42a2c8df" />
