### PR TITLE
Attempt at fixing plotting errors on deployed app

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -828,15 +828,15 @@ const DnDFlow = () => {
         stack: error.stack,
         response: error.response || 'No response object'
       });
-      
-      if (sseRef.current) { 
-        sseRef.current.close(); 
-        sseRef.current = null; 
+
+      if (sseRef.current) {
+        sseRef.current.close();
+        sseRef.current = null;
       }
-      
+
       // Provide more specific error messages
       let errorMessage = 'Failed to run Pathsim simulation. Make sure the backend is running.';
-      
+
       if (error.message.includes('JSON')) {
         errorMessage = 'Server response was not valid JSON. This might be due to a server error or network issue.';
       } else if (error.message.includes('HTTP')) {
@@ -844,7 +844,7 @@ const DnDFlow = () => {
       } else if (error.message.includes('empty response')) {
         errorMessage = 'Server returned empty response. The simulation might have failed silently.';
       }
-      
+
       alert(`${errorMessage} : ${error.message}`);
     }
   };

--- a/src/backend.py
+++ b/src/backend.py
@@ -534,6 +534,25 @@ def catch_all(path):
         return jsonify({"error": "Route not found"}), 404
 
 
+# Global error handler to ensure all errors return JSON
+@app.errorhandler(Exception)
+def handle_exception(e):
+    """Global exception handler to ensure JSON responses."""
+    import traceback
+
+    error_details = traceback.format_exc()
+    print(f"Unhandled exception: {error_details}")
+
+    # For HTTP exceptions, return the original response
+    if hasattr(e, "code"):
+        return jsonify(
+            {"success": False, "error": f"HTTP {e.code}: {str(e)}"}
+        ), getattr(e, "code", 500)
+
+    # For all other exceptions, return a generic JSON error
+    return jsonify({"success": False, "error": f"Internal server error: {str(e)}"}), 500
+
+
 if __name__ == "__main__":
     port = int(os.getenv("PORT", 8000))
     app.run(host="0.0.0.0", port=port, debug=os.getenv("FLASK_ENV") != "production")


### PR DESCRIPTION
I started noticing that on the deployed app, long simulations (eg. the ARC model) would run fine but then display:

```
Failed to run Pathsim simulation. Make sure the backend is running. : Failed to execute 'json' on 'Response': Unexpected end of JSON input
```

before plotting (and end up not plotting...)

This is an attempt at fixing that by adding more logic inside the infinite loop