### PR TITLE
Persistent recent-files list & IndexedDB-backed autosave

### DIFF
--- a/src/lib/schema/fileOps.ts
+++ b/src/lib/schema/fileOps.ts
@@ -32,7 +32,18 @@ import { downloadJson } from '$lib/utils/download';
 import { confirmationStore } from '$lib/stores/confirmation';
 import { nodeRegistry } from '$lib/nodes';
 import { NODE_TYPES } from '$lib/constants/nodeTypes';
-import { AUTOSAVE_KEY, kvDelete, kvGet, kvHas, kvSet } from './handleStore';
+import {
+	AUTOSAVE_KEY,
+	kvDelete,
+	kvGet,
+	kvHas,
+	kvSet,
+	recentIdFor,
+	recentsAdd,
+	recentsList,
+	recentsRemove,
+	type RecentFile
+} from './handleStore';
 
 const LEGACY_STORAGE_KEY = 'pathview_autosave';
 const FILE_EXTENSION = '.pvm';
@@ -418,6 +429,7 @@ export async function saveFile(): Promise<boolean> {
 			const writable = await currentFileHandle.createWritable();
 			await writable.write(json);
 			await writable.close();
+			void rememberRecent(currentFileHandle);
 			return true;
 		} catch (error) {
 			// User may have revoked permission, fall through to Save As
@@ -456,6 +468,7 @@ export async function saveAsFile(): Promise<boolean> {
 			// Update current file reference
 			currentFileHandle = handle;
 			currentFileNameStore.set(name);
+			void rememberRecent(handle);
 			return true;
 		} catch (error: any) {
 			if (error.name === 'AbortError') {
@@ -704,6 +717,7 @@ async function importModel(
 		componentFile.metadata.name ||
 		null
 	);
+	if (currentFileHandle) void rememberRecent(currentFileHandle);
 
 	return { success: true, type: 'model' };
 }
@@ -856,4 +870,87 @@ export async function openImportDialog(
 		input.oncancel = () => resolve({ success: false, type: 'model', cancelled: true });
 		input.click();
 	});
+}
+
+// =============================================================================
+// RECENT FILES (FileSystemFileHandle LRU in IndexedDB)
+// =============================================================================
+
+async function rememberRecent(handle: FileSystemFileHandle): Promise<void> {
+	try {
+		await recentsAdd({ id: recentIdFor(handle), name: handle.name, handle });
+	} catch (e) {
+		console.warn('Failed to remember recent file:', e);
+	}
+}
+
+/**
+ * List recently opened/saved files (most recent first). Only meaningful on
+ * browsers with the File System Access API — others return an empty list.
+ */
+export async function listRecentFiles(): Promise<RecentFile[]> {
+	if (!hasFileSystemAccess()) return [];
+	try {
+		return await recentsList();
+	} catch (e) {
+		console.warn('Failed to list recent files:', e);
+		return [];
+	}
+}
+
+/**
+ * Open a recently-used file by its recents id. Triggers the permission
+ * re-prompt the first time per session, then loads the file in place (same
+ * code path as `openImportDialog`'s success branch). Stale entries (file
+ * moved/deleted, permission denied) are evicted from the recents list.
+ */
+export async function openRecentFile(id: string): Promise<ImportResult> {
+	if (!hasFileSystemAccess()) {
+		return { success: false, type: 'model', error: 'File System Access API not available' };
+	}
+	let entry: RecentFile | undefined;
+	try {
+		const all = await recentsList();
+		entry = all.find((r) => r.id === id);
+	} catch (e) {
+		return {
+			success: false,
+			type: 'model',
+			error: e instanceof Error ? e.message : 'Failed to read recent files'
+		};
+	}
+	if (!entry) {
+		return { success: false, type: 'model', error: 'Recent file no longer tracked' };
+	}
+
+	try {
+		const handle = entry.handle as FileSystemFileHandle & {
+			queryPermission?: (d: { mode: 'readwrite' }) => Promise<PermissionState>;
+			requestPermission?: (d: { mode: 'readwrite' }) => Promise<PermissionState>;
+		};
+		if (handle.queryPermission && handle.requestPermission) {
+			let perm = await handle.queryPermission({ mode: 'readwrite' });
+			if (perm !== 'granted') {
+				perm = await handle.requestPermission({ mode: 'readwrite' });
+			}
+			if (perm !== 'granted') {
+				return { success: false, type: 'model', cancelled: true };
+			}
+		}
+		const file = await handle.getFile();
+		return importFile(file, { fileHandle: handle, fileName: handle.name });
+	} catch (e: any) {
+		// File was moved, deleted, or the user revoked permission — evict it
+		await recentsRemove(id).catch(() => undefined);
+		return {
+			success: false,
+			type: 'model',
+			error: e instanceof Error ? e.message : 'Failed to open recent file'
+		};
+	}
+}
+
+/** Remove a single recent-files entry (e.g., user clicks an "x" in the menu). */
+export async function removeRecentFile(id: string): Promise<void> {
+	await recentsRemove(id);
 }

--- a/src/lib/schema/fileOps.ts
+++ b/src/lib/schema/fileOps.ts
@@ -32,8 +32,9 @@ import { downloadJson } from '$lib/utils/download';
 import { confirmationStore } from '$lib/stores/confirmation';
 import { nodeRegistry } from '$lib/nodes';
 import { NODE_TYPES } from '$lib/constants/nodeTypes';
+import { AUTOSAVE_KEY, kvDelete, kvGet, kvHas, kvSet } from './handleStore';
 
-const STORAGE_KEY = 'pathview_autosave';
+const LEGACY_STORAGE_KEY = 'pathview_autosave';
 const FILE_EXTENSION = '.pvm';
 const LEGACY_EXTENSION = '.json';
 
@@ -318,12 +319,13 @@ export async function loadGraphFile(
 }
 
 /**
- * Save to localStorage (autosave)
+ * Save autosave snapshot to IndexedDB. Async because IDB is async; callers
+ * fire-and-forget unless they need to chain off completion.
  */
-export function autoSave(): void {
+export async function autoSave(): Promise<void> {
 	try {
 		const file = createGraphFile('Autosave');
-		localStorage.setItem(STORAGE_KEY, JSON.stringify(file));
+		await kvSet(AUTOSAVE_KEY, file);
 	} catch (error) {
 		console.warn('Autosave failed:', error);
 	}
@@ -337,24 +339,44 @@ export function debouncedAutoSave(delayMs: number = 500): void {
 		clearTimeout(autosaveDebounceTimer);
 	}
 	autosaveDebounceTimer = setTimeout(() => {
-		autoSave();
+		void autoSave();
 		autosaveDebounceTimer = null;
 	}, delayMs);
 }
 
 /**
- * Load from localStorage (restore autosave)
+ * One-shot migration from the old `localStorage` autosave (key
+ * `pathview_autosave`) to IDB. Runs lazily on the first IDB read/check.
+ */
+async function migrateLegacyAutosave(): Promise<GraphFile | null> {
+	try {
+		const raw = localStorage.getItem(LEGACY_STORAGE_KEY);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as GraphFile;
+		if (parsed?.version && parsed?.graph) {
+			await kvSet(AUTOSAVE_KEY, parsed);
+			localStorage.removeItem(LEGACY_STORAGE_KEY);
+			return parsed;
+		}
+		localStorage.removeItem(LEGACY_STORAGE_KEY);
+		return null;
+	} catch {
+		localStorage.removeItem(LEGACY_STORAGE_KEY);
+		return null;
+	}
+}
+
+/**
+ * Load autosave snapshot from IDB (with one-time localStorage migration)
  */
 export async function loadAutoSave(): Promise<boolean> {
 	try {
-		const data = localStorage.getItem(STORAGE_KEY);
-		if (!data) return false;
+		let file = await kvGet<GraphFile>(AUTOSAVE_KEY);
+		if (!file) file = (await migrateLegacyAutosave()) ?? undefined;
+		if (!file) return false;
 
-		const file = JSON.parse(data) as GraphFile;
-
-		// Validate the file has proper structure
 		if (!file.version || !file.graph) {
-			clearAutoSave();
+			await clearAutoSave();
 			return false;
 		}
 
@@ -362,7 +384,7 @@ export async function loadAutoSave(): Promise<boolean> {
 		return true;
 	} catch (error) {
 		console.warn('Failed to restore autosave, clearing:', error);
-		clearAutoSave();
+		await clearAutoSave();
 		return false;
 	}
 }
@@ -370,15 +392,18 @@ export async function loadAutoSave(): Promise<boolean> {
 /**
  * Clear autosave
  */
-export function clearAutoSave(): void {
-	localStorage.removeItem(STORAGE_KEY);
+export async function clearAutoSave(): Promise<void> {
+	await kvDelete(AUTOSAVE_KEY);
+	localStorage.removeItem(LEGACY_STORAGE_KEY);
 }
 
 /**
- * Check if autosave exists
+ * Check if autosave exists (migrates legacy localStorage entry on the way)
  */
-export function hasAutoSave(): boolean {
-	return localStorage.getItem(STORAGE_KEY) !== null;
+export async function hasAutoSave(): Promise<boolean> {
+	if (await kvHas(AUTOSAVE_KEY)) return true;
+	const migrated = await migrateLegacyAutosave();
+	return migrated !== null;
 }
 
 /**
@@ -471,7 +496,7 @@ export function newGraph(): void {
 	consoleStore.clear();
 	settingsStore.reset();
 	historyStore.clear();
-	clearAutoSave();
+	void clearAutoSave();
 	clearCurrentFile();
 }
 
@@ -480,7 +505,9 @@ export function newGraph(): void {
  * Returns cleanup function
  */
 export function setupAutoSave(intervalMs: number = 30000): () => void {
-	const timer = setInterval(autoSave, intervalMs);
+	const timer = setInterval(() => {
+		void autoSave();
+	}, intervalMs);
 	return () => clearInterval(timer);
 }
 

--- a/src/lib/schema/handleStore.ts
+++ b/src/lib/schema/handleStore.ts
@@ -1,0 +1,138 @@
+/**
+ * IndexedDB-backed storage for autosave snapshots and persisted
+ * File System Access API handles.
+ *
+ * Two object stores:
+ *   - `kv`      — simple key/value (used for the autosave blob, single row)
+ *   - `recents` — LRU of file handles with metadata (last 10 entries)
+ *
+ * Handles are structured-cloneable; the browser persists them as-is and we
+ * re-prompt for permission via `handle.requestPermission` when reopening.
+ */
+
+const DB_NAME = 'pathview';
+const DB_VERSION = 1;
+const KV_STORE = 'kv';
+const RECENTS_STORE = 'recents';
+const RECENTS_LIMIT = 10;
+
+export const AUTOSAVE_KEY = 'autosave';
+
+export interface RecentFile {
+	id: string;
+	name: string;
+	handle: FileSystemFileHandle;
+	lastOpened: number;
+}
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function openDb(): Promise<IDBDatabase> {
+	if (dbPromise) return dbPromise;
+	dbPromise = new Promise((resolve, reject) => {
+		const req = indexedDB.open(DB_NAME, DB_VERSION);
+		req.onupgradeneeded = () => {
+			const db = req.result;
+			if (!db.objectStoreNames.contains(KV_STORE)) {
+				db.createObjectStore(KV_STORE);
+			}
+			if (!db.objectStoreNames.contains(RECENTS_STORE)) {
+				const store = db.createObjectStore(RECENTS_STORE, { keyPath: 'id' });
+				store.createIndex('lastOpened', 'lastOpened');
+			}
+		};
+		req.onsuccess = () => resolve(req.result);
+		req.onerror = () => reject(req.error);
+		req.onblocked = () => reject(new Error('IndexedDB open blocked'));
+	});
+	return dbPromise;
+}
+
+function tx<T>(
+	storeName: string,
+	mode: IDBTransactionMode,
+	run: (store: IDBObjectStore) => IDBRequest<T> | Promise<T>
+): Promise<T> {
+	return openDb().then(
+		(db) =>
+			new Promise<T>((resolve, reject) => {
+				const transaction = db.transaction(storeName, mode);
+				const store = transaction.objectStore(storeName);
+				let result: T;
+				Promise.resolve(run(store)).then((r) => {
+					if (r && typeof (r as IDBRequest).addEventListener === 'function') {
+						const req = r as IDBRequest<T>;
+						req.onsuccess = () => {
+							result = req.result;
+						};
+						req.onerror = () => reject(req.error);
+					} else {
+						result = r as T;
+					}
+				});
+				transaction.oncomplete = () => resolve(result);
+				transaction.onerror = () => reject(transaction.error);
+				transaction.onabort = () => reject(transaction.error);
+			})
+	);
+}
+
+// ─── KV ────────────────────────────────────────────────────────────────────
+
+export async function kvGet<T = unknown>(key: string): Promise<T | undefined> {
+	return tx<T | undefined>(KV_STORE, 'readonly', (store) => store.get(key));
+}
+
+export async function kvSet(key: string, value: unknown): Promise<void> {
+	await tx(KV_STORE, 'readwrite', (store) => store.put(value, key));
+}
+
+export async function kvDelete(key: string): Promise<void> {
+	await tx(KV_STORE, 'readwrite', (store) => store.delete(key));
+}
+
+export async function kvHas(key: string): Promise<boolean> {
+	const v = await tx<IDBValidKey | undefined>(KV_STORE, 'readonly', (store) => store.getKey(key));
+	return v !== undefined;
+}
+
+// ─── Recent files ──────────────────────────────────────────────────────────
+
+export async function recentsList(): Promise<RecentFile[]> {
+	const all = await tx<RecentFile[]>(RECENTS_STORE, 'readonly', (store) => store.getAll());
+	return all.sort((a, b) => b.lastOpened - a.lastOpened);
+}
+
+export async function recentsAdd(entry: Omit<RecentFile, 'lastOpened'>): Promise<void> {
+	const now = Date.now();
+	await tx(RECENTS_STORE, 'readwrite', (store) => store.put({ ...entry, lastOpened: now }));
+	// Trim to LRU_LIMIT — keep newest, evict the rest
+	const all = await recentsList();
+	if (all.length > RECENTS_LIMIT) {
+		const toEvict = all.slice(RECENTS_LIMIT);
+		await tx(RECENTS_STORE, 'readwrite', (store) => {
+			toEvict.forEach((e) => store.delete(e.id));
+			return store.count();
+		});
+	}
+}
+
+export async function recentsRemove(id: string): Promise<void> {
+	await tx(RECENTS_STORE, 'readwrite', (store) => store.delete(id));
+}
+
+export async function recentsClear(): Promise<void> {
+	await tx(RECENTS_STORE, 'readwrite', (store) => store.clear());
+}
+
+/**
+ * Stable id for a handle. Same file (by name + kind) collapses into one
+ * recents row instead of accumulating duplicates across sessions.
+ */
+export function recentIdFor(handle: FileSystemFileHandle): string {
+	return `${handle.kind}:${handle.name}`;
+}
+
+export function hasFileSystemAccess(): boolean {
+	return typeof window !== 'undefined' && 'showOpenFilePicker' in window;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -49,7 +49,9 @@
 	import { initBackendFromUrl, autoDetectBackend } from '$lib/pyodide/backend';
 	import { runGraphStreamingSimulation, validateGraphSimulation, exportToPython } from '$lib/pyodide/pathsimRunner';
 	import { consoleStore } from '$lib/stores/console';
-	import { newGraph, saveFile, saveAsFile, setupAutoSave, clearAutoSave, debouncedAutoSave, openImportDialog, importFromUrl, currentFileName } from '$lib/schema/fileOps';
+	import { newGraph, saveFile, saveAsFile, setupAutoSave, clearAutoSave, debouncedAutoSave, openImportDialog, importFromUrl, currentFileName, loadGraphFile } from '$lib/schema/fileOps';
+	import { AUTOSAVE_KEY, kvGet } from '$lib/schema/handleStore';
+	import type { GraphFile } from '$lib/nodes/types';
 	import { confirmationStore } from '$lib/stores/confirmation';
 	import ConfirmationModal from '$lib/components/ConfirmationModal.svelte';
 	import { triggerFitView, triggerZoomIn, triggerZoomOut, triggerPan, getViewportCenter, screenToFlow, triggerClearSelection, triggerNudge, hasAnySelection, setFitViewPadding, triggerFlyInAnimation } from '$lib/stores/viewActions';
@@ -647,8 +649,12 @@
 			consoleLogCount = logs.length;
 		});
 
-		// Always start with clean slate
-		void clearAutoSave();
+		// Snapshot the previous session's autosave (if any) *before* setting up
+		// subscriptions, so the upcoming subscribe-fire / debounced writes
+		// cannot race-overwrite it in IDB while the user is still answering
+		// the Restore prompt. We keep the snapshot in memory and reload from
+		// there on confirm.
+		const initialAutosavePromise = kvGet<GraphFile>(AUTOSAVE_KEY);
 
 		// Setup periodic autosave (backup)
 		const cleanupAutoSave = setupAutoSave(30000);
@@ -670,6 +676,30 @@
 		};
 		window.addEventListener('run-simulation', handleRunSimulation);
 		window.addEventListener('continue-simulation', handleContinueSimulation);
+
+		// Offer to restore the previous session's autosave (skip if a URL
+		// model is loading — that takes precedence over restore).
+		void (async () => {
+			const snapshot = await initialAutosavePromise;
+			if (!snapshot || urlModelConfig) return;
+			const ok = await confirmationStore.show({
+				title: 'Restore last session?',
+				message: 'PathView found an autosaved version of your last session. Restore it?',
+				confirmText: 'Restore',
+				cancelText: 'Discard'
+			});
+			if (ok) {
+				try {
+					await loadGraphFile(snapshot);
+					setTimeout(() => triggerFitView(), 100);
+				} catch (e) {
+					console.warn('Failed to restore autosave:', e);
+					await clearAutoSave();
+				}
+			} else {
+				await clearAutoSave();
+			}
+		})();
 
 		return () => {
 			// Cleanup store subscriptions

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -648,7 +648,7 @@
 		});
 
 		// Always start with clean slate
-		clearAutoSave();
+		void clearAutoSave();
 
 		// Setup periodic autosave (backup)
 		const cleanupAutoSave = setupAutoSave(30000);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1075,21 +1075,48 @@
 		}
 	}
 
-	// ── Recent files menu ────────────────────────────────────────────────────
+	// ── Recent files hover menu ──────────────────────────────────────────────
 	const recentFilesSupported = hasFileSystemAccess();
 	let recentFiles = $state<RecentFile[]>([]);
 	let recentFilesMenuOpen = $state(false);
+	let recentOpenTimer: ReturnType<typeof setTimeout> | null = null;
+	let recentCloseTimer: ReturnType<typeof setTimeout> | null = null;
+	const RECENT_HOVER_OPEN_MS = 250;
+	const RECENT_HOVER_CLOSE_MS = 180;
 
-	async function toggleRecentFilesMenu() {
-		if (recentFilesMenuOpen) {
-			recentFilesMenuOpen = false;
-			return;
+	function clearRecentTimers() {
+		if (recentOpenTimer) {
+			clearTimeout(recentOpenTimer);
+			recentOpenTimer = null;
 		}
-		recentFiles = await listRecentFiles();
-		recentFilesMenuOpen = true;
+		if (recentCloseTimer) {
+			clearTimeout(recentCloseTimer);
+			recentCloseTimer = null;
+		}
+	}
+
+	function handleOpenGroupEnter() {
+		if (!recentFilesSupported) return;
+		clearRecentTimers();
+		recentOpenTimer = setTimeout(async () => {
+			recentOpenTimer = null;
+			const list = await listRecentFiles();
+			if (list.length === 0) return; // no menu when empty
+			recentFiles = list;
+			recentFilesMenuOpen = true;
+		}, RECENT_HOVER_OPEN_MS);
+	}
+
+	function handleOpenGroupLeave() {
+		clearRecentTimers();
+		recentCloseTimer = setTimeout(() => {
+			recentFilesMenuOpen = false;
+			recentCloseTimer = null;
+		}, RECENT_HOVER_CLOSE_MS);
 	}
 
 	async function handleOpenRecent(id: string) {
+		clearRecentTimers();
 		recentFilesMenuOpen = false;
 		const result = await openRecentFile(id);
 		if (result.success && result.type === 'model') {
@@ -1104,10 +1131,6 @@
 		await removeRecentFile(id);
 		recentFiles = await listRecentFiles();
 		if (recentFiles.length === 0) recentFilesMenuOpen = false;
-	}
-
-	function handleRecentMenuBackdropClick() {
-		recentFilesMenuOpen = false;
 	}
 
 	/**
@@ -1279,46 +1302,33 @@
 			<button class="toolbar-btn" onclick={handleNew} use:tooltip={"New"} aria-label="New">
 				<Icon name="new-canvas" size={16} />
 			</button>
-			<div class="open-group">
-				<button class="toolbar-btn open-main" onclick={handleOpen} use:tooltip={{ text: "Open/Import", shortcut: "Ctrl+O" }} aria-label="Open/Import">
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
+			<div
+				class="open-group"
+				onmouseenter={handleOpenGroupEnter}
+				onmouseleave={handleOpenGroupLeave}
+			>
+				<button class="toolbar-btn" onclick={handleOpen} use:tooltip={{ text: "Open/Import", shortcut: "Ctrl+O" }} aria-label="Open/Import">
 					<Icon name="download" size={16} />
 				</button>
-				{#if recentFilesSupported}
-					<button
-						class="toolbar-btn open-caret"
-						class:active={recentFilesMenuOpen}
-						onclick={toggleRecentFilesMenu}
-						use:tooltip={"Recent files"}
-						aria-label="Recent files"
-						aria-haspopup="menu"
-						aria-expanded={recentFilesMenuOpen}
-					>
-						<Icon name="chevron-down" size={12} />
-					</button>
-					{#if recentFilesMenuOpen}
-						<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
-						<div class="recent-menu-backdrop" onclick={handleRecentMenuBackdropClick}></div>
-						<div class="recent-menu" role="menu">
-							{#if recentFiles.length === 0}
-								<div class="recent-empty">No recent files yet</div>
-							{:else}
-								{#each recentFiles as recent (recent.id)}
-									<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
-									<div class="recent-item" role="menuitem" tabindex="0" onclick={() => handleOpenRecent(recent.id)}>
-										<Icon name="file" size={14} />
-										<span class="recent-name" title={recent.name}>{recent.name}</span>
-										<button
-											class="recent-remove"
-											onclick={(e) => handleRemoveRecent(recent.id, e)}
-											aria-label="Remove from recents"
-										>
-											<Icon name="x" size={12} />
-										</button>
-									</div>
-								{/each}
-							{/if}
-						</div>
-					{/if}
+				{#if recentFilesSupported && recentFilesMenuOpen}
+					<div class="recent-menu" role="menu">
+						<div class="recent-menu-header">Recent files</div>
+						{#each recentFiles as recent (recent.id)}
+							<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+							<div class="recent-item" role="menuitem" tabindex="0" onclick={() => handleOpenRecent(recent.id)}>
+								<Icon name="file" size={14} />
+								<span class="recent-name" title={recent.name}>{recent.name}</span>
+								<button
+									class="recent-remove"
+									onclick={(e) => handleRemoveRecent(recent.id, e)}
+									aria-label="Remove from recents"
+								>
+									<Icon name="x" size={12} />
+								</button>
+							</div>
+						{/each}
+					</div>
 				{/if}
 			</div>
 			<button
@@ -1835,46 +1845,42 @@
 		position: relative;
 	}
 
-	/* Open + recent-files caret as a tight pair */
+	/* Open button + hover-revealed recent-files menu */
 	.open-group {
 		position: relative;
-		display: flex;
-		gap: 1px;
-	}
-
-	.open-caret {
-		width: 16px;
-		border-radius: var(--radius-md);
-		padding: 0;
-	}
-
-	.recent-menu-backdrop {
-		position: fixed;
-		inset: 0;
-		z-index: var(--z-popover, 1000);
 	}
 
 	.recent-menu {
 		position: absolute;
-		top: calc(100% + 4px);
-		right: 0;
+		top: 100%;
+		left: 0;
+		/* Bridge the gap so the mouse can cross from button to menu without
+		   triggering mouseleave on the wrapper. */
+		padding-top: 4px;
 		min-width: 240px;
 		max-width: 360px;
+		z-index: var(--z-popover, 1000);
+	}
+
+	.recent-menu::before {
+		content: '';
+		display: block;
 		background: var(--surface-raised);
 		border: 1px solid var(--border);
 		border-radius: var(--radius-md);
 		box-shadow: var(--shadow-md, 0 6px 16px rgba(0, 0, 0, 0.25));
-		padding: 4px;
-		z-index: calc(var(--z-popover, 1000) + 1);
-		max-height: 320px;
-		overflow-y: auto;
+		position: absolute;
+		inset: 4px 0 0 0;
+		z-index: -1;
 	}
 
-	.recent-empty {
-		padding: 8px 10px;
-		font-size: 11px;
-		color: var(--text-muted);
-		text-align: center;
+	.recent-menu-header {
+		padding: 6px 10px 4px;
+		font-size: 10px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
+		color: var(--text-disabled);
 	}
 
 	.recent-item {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1854,9 +1854,10 @@
 		position: absolute;
 		top: 100%;
 		left: 0;
-		/* Bridge the gap so the mouse can cross from button to menu without
-		   triggering mouseleave on the wrapper. */
-		padding-top: 4px;
+		/* Top padding bridges the gap so the mouse can cross from button to
+		   menu without triggering mouseleave. The other sides are inner
+		   panel padding so item hover doesn't touch the rounded panel edge. */
+		padding: 4px 4px 4px 4px;
 		min-width: 240px;
 		max-width: 360px;
 		z-index: var(--z-popover, 1000);
@@ -1898,6 +1899,7 @@
 	.recent-item:hover,
 	.recent-item:focus-visible {
 		background: var(--surface-hover);
+		color: var(--text);
 		outline: none;
 	}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1887,17 +1887,17 @@
 		display: flex;
 		align-items: center;
 		gap: 8px;
-		padding: 6px 8px;
-		border-radius: var(--radius-sm, 4px);
+		padding: 6px 10px;
+		border-radius: var(--radius-sm);
 		cursor: pointer;
 		color: var(--text-muted);
-		font-size: 12px;
+		font-size: 11px;
+		transition: background var(--transition-fast);
 	}
 
 	.recent-item:hover,
 	.recent-item:focus-visible {
-		background: var(--surface);
-		color: var(--text);
+		background: var(--surface-hover);
 		outline: none;
 	}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -49,8 +49,8 @@
 	import { initBackendFromUrl, autoDetectBackend } from '$lib/pyodide/backend';
 	import { runGraphStreamingSimulation, validateGraphSimulation, exportToPython } from '$lib/pyodide/pathsimRunner';
 	import { consoleStore } from '$lib/stores/console';
-	import { newGraph, saveFile, saveAsFile, setupAutoSave, clearAutoSave, debouncedAutoSave, openImportDialog, importFromUrl, currentFileName, loadGraphFile } from '$lib/schema/fileOps';
-	import { AUTOSAVE_KEY, kvGet } from '$lib/schema/handleStore';
+	import { newGraph, saveFile, saveAsFile, setupAutoSave, clearAutoSave, debouncedAutoSave, openImportDialog, importFromUrl, currentFileName, loadGraphFile, listRecentFiles, openRecentFile, removeRecentFile } from '$lib/schema/fileOps';
+	import { AUTOSAVE_KEY, kvGet, hasFileSystemAccess, type RecentFile } from '$lib/schema/handleStore';
 	import type { GraphFile } from '$lib/nodes/types';
 	import { confirmationStore } from '$lib/stores/confirmation';
 	import ConfirmationModal from '$lib/components/ConfirmationModal.svelte';
@@ -1075,6 +1075,41 @@
 		}
 	}
 
+	// ── Recent files menu ────────────────────────────────────────────────────
+	const recentFilesSupported = hasFileSystemAccess();
+	let recentFiles = $state<RecentFile[]>([]);
+	let recentFilesMenuOpen = $state(false);
+
+	async function toggleRecentFilesMenu() {
+		if (recentFilesMenuOpen) {
+			recentFilesMenuOpen = false;
+			return;
+		}
+		recentFiles = await listRecentFiles();
+		recentFilesMenuOpen = true;
+	}
+
+	async function handleOpenRecent(id: string) {
+		recentFilesMenuOpen = false;
+		const result = await openRecentFile(id);
+		if (result.success && result.type === 'model') {
+			setTimeout(() => triggerFitView(), 100);
+		} else if (result.error) {
+			consoleStore.error(`[open recent] ${result.error}`);
+		}
+	}
+
+	async function handleRemoveRecent(id: string, e: MouseEvent) {
+		e.stopPropagation();
+		await removeRecentFile(id);
+		recentFiles = await listRecentFiles();
+		if (recentFiles.length === 0) recentFilesMenuOpen = false;
+	}
+
+	function handleRecentMenuBackdropClick() {
+		recentFilesMenuOpen = false;
+	}
+
 	/**
 	 * Expand GitHub shorthand to raw.githubusercontent.com URL
 	 * Format: owner/repo/path/to/file.pvm
@@ -1244,9 +1279,48 @@
 			<button class="toolbar-btn" onclick={handleNew} use:tooltip={"New"} aria-label="New">
 				<Icon name="new-canvas" size={16} />
 			</button>
-			<button class="toolbar-btn" onclick={handleOpen} use:tooltip={{ text: "Open/Import", shortcut: "Ctrl+O" }} aria-label="Open/Import">
-				<Icon name="download" size={16} />
-			</button>
+			<div class="open-group">
+				<button class="toolbar-btn open-main" onclick={handleOpen} use:tooltip={{ text: "Open/Import", shortcut: "Ctrl+O" }} aria-label="Open/Import">
+					<Icon name="download" size={16} />
+				</button>
+				{#if recentFilesSupported}
+					<button
+						class="toolbar-btn open-caret"
+						class:active={recentFilesMenuOpen}
+						onclick={toggleRecentFilesMenu}
+						use:tooltip={"Recent files"}
+						aria-label="Recent files"
+						aria-haspopup="menu"
+						aria-expanded={recentFilesMenuOpen}
+					>
+						<Icon name="chevron-down" size={12} />
+					</button>
+					{#if recentFilesMenuOpen}
+						<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+						<div class="recent-menu-backdrop" onclick={handleRecentMenuBackdropClick}></div>
+						<div class="recent-menu" role="menu">
+							{#if recentFiles.length === 0}
+								<div class="recent-empty">No recent files yet</div>
+							{:else}
+								{#each recentFiles as recent (recent.id)}
+									<!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
+									<div class="recent-item" role="menuitem" tabindex="0" onclick={() => handleOpenRecent(recent.id)}>
+										<Icon name="file" size={14} />
+										<span class="recent-name" title={recent.name}>{recent.name}</span>
+										<button
+											class="recent-remove"
+											onclick={(e) => handleRemoveRecent(recent.id, e)}
+											aria-label="Remove from recents"
+										>
+											<Icon name="x" size={12} />
+										</button>
+									</div>
+								{/each}
+							{/if}
+						</div>
+					{/if}
+				{/if}
+			</div>
 			<button
 				class="toolbar-btn"
 				onclick={() => handleSave()}
@@ -1759,6 +1833,100 @@
 
 	.toolbar-btn.stage-btn {
 		position: relative;
+	}
+
+	/* Open + recent-files caret as a tight pair */
+	.open-group {
+		position: relative;
+		display: flex;
+		gap: 1px;
+	}
+
+	.open-caret {
+		width: 16px;
+		border-radius: var(--radius-md);
+		padding: 0;
+	}
+
+	.recent-menu-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: var(--z-popover, 1000);
+	}
+
+	.recent-menu {
+		position: absolute;
+		top: calc(100% + 4px);
+		right: 0;
+		min-width: 240px;
+		max-width: 360px;
+		background: var(--surface-raised);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		box-shadow: var(--shadow-md, 0 6px 16px rgba(0, 0, 0, 0.25));
+		padding: 4px;
+		z-index: calc(var(--z-popover, 1000) + 1);
+		max-height: 320px;
+		overflow-y: auto;
+	}
+
+	.recent-empty {
+		padding: 8px 10px;
+		font-size: 11px;
+		color: var(--text-muted);
+		text-align: center;
+	}
+
+	.recent-item {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 6px 8px;
+		border-radius: var(--radius-sm, 4px);
+		cursor: pointer;
+		color: var(--text-muted);
+		font-size: 12px;
+	}
+
+	.recent-item:hover,
+	.recent-item:focus-visible {
+		background: var(--surface);
+		color: var(--text);
+		outline: none;
+	}
+
+	.recent-name {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.recent-remove {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 18px;
+		height: 18px;
+		padding: 0;
+		border: none;
+		background: transparent;
+		color: var(--text-muted);
+		cursor: pointer;
+		border-radius: var(--radius-sm, 4px);
+		opacity: 0;
+		transition: opacity var(--transition-fast), color var(--transition-fast);
+	}
+
+	.recent-item:hover .recent-remove,
+	.recent-item:focus-within .recent-remove {
+		opacity: 1;
+	}
+
+	.recent-remove:hover {
+		color: var(--error);
+		background: color-mix(in srgb, var(--error) 15%, transparent);
 	}
 
 	.mutation-badge {


### PR DESCRIPTION
Closes #288.

## Summary
- Autosave storage moved from `localStorage` to IndexedDB — removes the ~5–10 MB per-origin cap; large graphs no longer fail silently. One-time migration of any existing `pathview_autosave` localStorage entry.
- On load, if an autosave snapshot exists and no `?model=` URL is present, a confirmation dialog offers to restore the previous session (replaces the silent `clearAutoSave()` at startup).
- `FileSystemFileHandle`s are persisted to IndexedDB as an LRU (max 10) on every successful Save/Save-As/Open.
- Open-button (toolbar) reveals a Recent-files menu on hover. Click an entry → permission re-prompt → load in place. Stale entries auto-evict on failure; per-item "x" removes manually. Hidden on browsers without the File System Access API (Firefox/Safari) — current behaviour preserved.