### PR TITLE
Custom port labels

### DIFF
--- a/src/lib/components/dialogs/BlockPropertiesDialog.svelte
+++ b/src/lib/components/dialogs/BlockPropertiesDialog.svelte
@@ -420,6 +420,9 @@
 										/>
 									</div>
 								{/each}
+								{#if node.inputs.length > 0 && node.outputs.length > 0}
+									<div class="port-divider"></div>
+								{/if}
 								{#each node.outputs as port, i (port.id)}
 									<div class="param-item">
 										<label for="port-out-{i}">out {i}</label>
@@ -518,6 +521,12 @@
 	.param-input-row > :first-child {
 		flex: 1;
 		min-width: 0;
+	}
+
+	.port-divider {
+		height: 1px;
+		background: var(--border);
+		margin: 4px 0;
 	}
 
 	/* Pin button */

--- a/src/lib/components/dialogs/BlockPropertiesDialog.svelte
+++ b/src/lib/components/dialogs/BlockPropertiesDialog.svelte
@@ -21,6 +21,8 @@
 	import { NODE_TYPES } from '$lib/constants/nodeTypes';
 	import { exportRecordingData } from '$lib/utils/csvExport';
 	import { createRecordingDataState } from '$lib/stores/recordingData.svelte';
+	import { getPortLabelConfigs } from '$lib/nodes/uiConfig';
+	import { PORT_NAME } from '$lib/constants/handles';
 
 	// Code preview state (declared early — referenced by subscription below)
 	let showCode = $state(false);
@@ -175,6 +177,24 @@
 		historyStore.mutate(() => graphStore.updateNodeParams(id, { _hidden: true }));
 		// Dialog targets a node that's now invisible; close it.
 		closeNodeDialog();
+	}
+
+	// Port-label editing — hide for blocks whose port names are driven by a
+	// regular param (Scope.labels, Adder.operations, …); for those the param
+	// itself is the source of truth and editing port names directly would be
+	// overwritten on the next param change.
+	const hasParamDrivenPortLabels = $derived(node ? getPortLabelConfigs(node.type).length > 0 : false);
+	const showPortLabels = $derived(
+		!!node && !hasParamDrivenPortLabels && (node.inputs.length > 0 || node.outputs.length > 0)
+	);
+
+	function handlePortNameChange(direction: 'input' | 'output', index: number, value: string) {
+		if (!node) return;
+		const id = node.id;
+		const trimmed = value.trim();
+		const fallback = direction === 'input' ? PORT_NAME.input(index) : PORT_NAME.output(index);
+		const name = trimmed === '' ? fallback : trimmed;
+		historyStore.mutate(() => graphStore.updateNodePortName(id, direction, index, name));
 	}
 
 	// Check if node is a recording node (Scope or Spectrum)
@@ -406,6 +426,39 @@
 						</div>
 					{:else}
 						<div class="no-params">No configurable parameters</div>
+					{/if}
+
+					<!-- Port labels — customise the names shown on each handle -->
+					{#if showPortLabels}
+						<div class="section">
+							<div class="section-title">Port labels</div>
+							<div class="params-grid">
+								{#each node.inputs as port, i (port.id)}
+									<div class="param-item">
+										<label for="port-in-{i}">in {i}</label>
+										<input
+											id="port-in-{i}"
+											type="text"
+											value={port.name}
+											placeholder={PORT_NAME.input(i)}
+											onchange={(e) => handlePortNameChange('input', i, e.currentTarget.value)}
+										/>
+									</div>
+								{/each}
+								{#each node.outputs as port, i (port.id)}
+									<div class="param-item">
+										<label for="port-out-{i}">out {i}</label>
+										<input
+											id="port-out-{i}"
+											type="text"
+											value={port.name}
+											placeholder={PORT_NAME.output(i)}
+											onchange={(e) => handlePortNameChange('output', i, e.currentTarget.value)}
+										/>
+									</div>
+								{/each}
+							</div>
+						</div>
 					{/if}
 
 					<!-- Documentation section (lazy loaded) -->

--- a/src/lib/components/dialogs/BlockPropertiesDialog.svelte
+++ b/src/lib/components/dialogs/BlockPropertiesDialog.svelte
@@ -526,7 +526,8 @@
 	.port-divider {
 		height: 1px;
 		background: var(--border);
-		margin: 4px 0;
+		/* Extend past the dialog-body padding so the line spans edge-to-edge. */
+		margin: var(--space-xs) calc(-1 * var(--space-md));
 	}
 
 	/* Pin button */

--- a/src/lib/components/dialogs/BlockPropertiesDialog.svelte
+++ b/src/lib/components/dialogs/BlockPropertiesDialog.svelte
@@ -26,6 +26,7 @@
 
 	// Code preview state (declared early — referenced by subscription below)
 	let showCode = $state(false);
+	let showPortLabels = $state(false);
 	let previewCode = $state('');
 	let editorContainer = $state<HTMLDivElement | undefined>(undefined);
 	let editorView: import('@codemirror/view').EditorView | null = null;
@@ -51,10 +52,12 @@
 			node = graphStore.getNode(id) || null;
 			// Reset to properties view when opening a new node
 			showCode = false;
+			showPortLabels = false;
 			destroyEditor();
 		} else {
 			node = null;
 			showCode = false;
+			showPortLabels = false;
 			destroyEditor();
 		}
 	});
@@ -146,8 +149,20 @@
 			const blockCode = generateBlockCode(node, allNodes, allConnections);
 			previewCode = header + blockCode;
 			copied = false;
+			showPortLabels = false;
 			showCode = true;
 			setTimeout(() => initEditor(), 0);
+		}
+	}
+
+	// Toggle port-labels view (same mutual-exclusion pattern as code view)
+	function togglePortLabelsView() {
+		if (showPortLabels) {
+			showPortLabels = false;
+		} else {
+			showCode = false;
+			destroyEditor();
+			showPortLabels = true;
 		}
 	}
 
@@ -184,7 +199,7 @@
 	// itself is the source of truth and editing port names directly would be
 	// overwritten on the next param change.
 	const hasParamDrivenPortLabels = $derived(node ? getPortLabelConfigs(node.type).length > 0 : false);
-	const showPortLabels = $derived(
+	const hasEditablePortLabels = $derived(
 		!!node && !hasParamDrivenPortLabels && (node.inputs.length > 0 || node.outputs.length > 0)
 	);
 
@@ -276,6 +291,8 @@
 		<div class="dialog-header">
 				{#if showCode}
 					<span id="dialog-title">Python Code</span>
+				{:else if showPortLabels}
+					<span id="dialog-title">Port Labels</span>
 				{:else}
 					<div class="node-info">
 						<input
@@ -306,7 +323,7 @@
 								<Icon name="copy" size={16} />
 							{/if}
 						</button>
-					{:else}
+					{:else if !showPortLabels}
 						<!-- Color picker -->
 						<ColorPicker
 							currentColor={currentColor}
@@ -348,15 +365,28 @@
 							</button>
 						{/if}
 					{/if}
-					<!-- Toggle code view button -->
-					<button
-						class="icon-btn"
-						onclick={toggleCodeView}
-						use:tooltip={showCode ? "View Properties" : "View Python Code"}
-						aria-label={showCode ? "View Properties" : "View Python Code"}
-					>
-						<Icon name={showCode ? "settings" : "braces"} size={16} />
-					</button>
+					<!-- Toggle port labels view button (hidden in code view) -->
+					{#if showPortLabels || (!showCode && hasEditablePortLabels)}
+						<button
+							class="icon-btn"
+							onclick={togglePortLabelsView}
+							use:tooltip={showPortLabels ? "View Properties" : "Edit Port Labels"}
+							aria-label={showPortLabels ? "View Properties" : "Edit Port Labels"}
+						>
+							<Icon name={showPortLabels ? "settings" : "tag"} size={16} />
+						</button>
+					{/if}
+					<!-- Toggle code view button (hidden in port-labels view) -->
+					{#if !showPortLabels}
+						<button
+							class="icon-btn"
+							onclick={toggleCodeView}
+							use:tooltip={showCode ? "View Properties" : "View Python Code"}
+							aria-label={showCode ? "View Properties" : "View Python Code"}
+						>
+							<Icon name={showCode ? "settings" : "braces"} size={16} />
+						</button>
+					{/if}
 					<button class="icon-btn" onclick={closeNodeDialog} aria-label="Close">
 						<Icon name="x" size={16} />
 					</button>
@@ -371,6 +401,40 @@
 							<div class="loading">Loading...</div>
 						{/if}
 					</div>
+				{:else if showPortLabels}
+					<!-- Port labels view -->
+					{#if node.inputs.length === 0 && node.outputs.length === 0}
+						<div class="no-params">No ports to label</div>
+					{:else}
+						<div class="section">
+							<div class="params-grid">
+								{#each node.inputs as port, i (port.id)}
+									<div class="param-item">
+										<label for="port-in-{i}">in {i}</label>
+										<input
+											id="port-in-{i}"
+											type="text"
+											value={port.name}
+											placeholder={PORT_NAME.input(i)}
+											onchange={(e) => handlePortNameChange('input', i, e.currentTarget.value)}
+										/>
+									</div>
+								{/each}
+								{#each node.outputs as port, i (port.id)}
+									<div class="param-item">
+										<label for="port-out-{i}">out {i}</label>
+										<input
+											id="port-out-{i}"
+											type="text"
+											value={port.name}
+											placeholder={PORT_NAME.output(i)}
+											onchange={(e) => handlePortNameChange('output', i, e.currentTarget.value)}
+										/>
+									</div>
+								{/each}
+							</div>
+						</div>
+					{/if}
 				{:else}
 					<!-- Parameters -->
 					{#if typeDef.params.length > 0}
@@ -428,45 +492,12 @@
 						<div class="no-params">No configurable parameters</div>
 					{/if}
 
-					<!-- Port labels — customise the names shown on each handle -->
-					{#if showPortLabels}
-						<div class="section">
-							<div class="section-title">Port labels</div>
-							<div class="params-grid">
-								{#each node.inputs as port, i (port.id)}
-									<div class="param-item">
-										<label for="port-in-{i}">in {i}</label>
-										<input
-											id="port-in-{i}"
-											type="text"
-											value={port.name}
-											placeholder={PORT_NAME.input(i)}
-											onchange={(e) => handlePortNameChange('input', i, e.currentTarget.value)}
-										/>
-									</div>
-								{/each}
-								{#each node.outputs as port, i (port.id)}
-									<div class="param-item">
-										<label for="port-out-{i}">out {i}</label>
-										<input
-											id="port-out-{i}"
-											type="text"
-											value={port.name}
-											placeholder={PORT_NAME.output(i)}
-											onchange={(e) => handlePortNameChange('output', i, e.currentTarget.value)}
-										/>
-									</div>
-								{/each}
-							</div>
-						</div>
-					{/if}
-
 					<!-- Documentation section (lazy loaded) -->
 					<DocumentationSection docstringHtml={docstringHtml} />
 				{/if}
 			</div>
 
-		{#if !showCode}
+		{#if !showCode && !showPortLabels}
 			<div class="dialog-footer">
 				<span class="hint">R rotate · X flip horizontal · Y flip vertical</span>
 			</div>

--- a/src/lib/stores/graph/helpers.ts
+++ b/src/lib/stores/graph/helpers.ts
@@ -69,7 +69,7 @@ export function deriveInterfaceNode(
 		outputs: parentSubsystem.inputs.map((port, i) => ({
 			id: `${interfaceNode.id}-output-${i}`,
 			nodeId: interfaceNode.id,
-			name: `in ${i}`,
+			name: port.name,
 			direction: 'output' as const,
 			index: i,
 			color: port.color
@@ -77,7 +77,7 @@ export function deriveInterfaceNode(
 		inputs: parentSubsystem.outputs.map((port, i) => ({
 			id: `${interfaceNode.id}-input-${i}`,
 			nodeId: interfaceNode.id,
-			name: `out ${i}`,
+			name: port.name,
 			direction: 'input' as const,
 			index: i,
 			color: port.color

--- a/src/lib/stores/graph/index.ts
+++ b/src/lib/stores/graph/index.ts
@@ -84,6 +84,7 @@ export const graphStore = {
 	removeInputPort: ports.removeInputPort,
 	addOutputPort: ports.addOutputPort,
 	removeOutputPort: ports.removeOutputPort,
+	updateNodePortName: ports.updateNodePortName,
 
 	// ==================== ANNOTATION OPERATIONS ====================
 	addAnnotation: annotations.addAnnotation,

--- a/src/lib/stores/graph/ports.ts
+++ b/src/lib/stores/graph/ports.ts
@@ -331,3 +331,47 @@ export function syncPortNamesFromLabels(
 		updateNodeById(nodeId, () => updated);
 	}
 }
+
+/**
+ * Rename a single port. For regular nodes this writes the new name into
+ * `node.{inputs|outputs}[index].name`. For Interface nodes, port names are
+ * derived from the parent Subsystem at read time, so we write to the parent
+ * instead (with the direction flipped, because Interface input ↔ Subsystem
+ * output).
+ */
+export function updateNodePortName(
+	nodeId: string,
+	direction: PortDirection,
+	index: number,
+	name: string
+): void {
+	const currentGraph = getCurrentGraph();
+	const node = currentGraph.nodes.get(nodeId);
+	if (!node) return;
+
+	const path = get(currentPath);
+
+	if (node.type === NODE_TYPES.INTERFACE && path.length > 0) {
+		const parentId = path[path.length - 1];
+		const parentPath = path.slice(0, -1);
+		const parentPortsKey = direction === 'input' ? 'outputs' : 'inputs';
+
+		updateParentSubsystem(parentPath, parentId, (parent) => {
+			const ports = parent[parentPortsKey] as PortInstance[];
+			if (index < 0 || index >= ports.length) return parent;
+			if (ports[index].name === name) return parent;
+			const newPorts = ports.map((p, i) => (i === index ? { ...p, name } : p));
+			return { ...parent, [parentPortsKey]: newPorts };
+		});
+		return;
+	}
+
+	updateNodeById(nodeId, (n) => {
+		const portsKey = direction === 'input' ? 'inputs' : 'outputs';
+		const ports = n[portsKey] as PortInstance[];
+		if (index < 0 || index >= ports.length) return n;
+		if (ports[index].name === name) return n;
+		const newPorts = ports.map((p, i) => (i === index ? { ...p, name } : p));
+		return { ...n, [portsKey]: newPorts };
+	});
+}

--- a/src/lib/stores/graph/state.ts
+++ b/src/lib/stores/graph/state.ts
@@ -95,11 +95,13 @@ export function getCurrentGraph(): {
 				...node,
 				name: subsystem.name,
 				color: subsystem.color,
-				// Subsystem inputs → Interface outputs (signals coming in)
+				// Subsystem inputs → Interface outputs (signals coming in).
+				// Port names come from the parent — that's the single source
+				// of truth so user-customised labels survive across renders.
 				outputs: subsystem.inputs.map((port, i) => ({
 					id: `${node.id}-output-${i}`,
 					nodeId: node.id,
-					name: `in ${i}`,
+					name: port.name,
 					direction: 'output' as const,
 					index: i,
 					color: port.color
@@ -108,7 +110,7 @@ export function getCurrentGraph(): {
 				inputs: subsystem.outputs.map((port, i) => ({
 					id: `${node.id}-input-${i}`,
 					nodeId: node.id,
-					name: `out ${i}`,
+					name: port.name,
 					direction: 'input' as const,
 					index: i,
 					color: port.color


### PR DESCRIPTION
Closes #289.

## Summary
- New `updateNodePortName(nodeId, direction, index, name)` store action writes the new label directly to `node.{inputs|outputs}[index].name`. Port names are already part of `NodeInstance` and persist in the `.pvm` file — no new params introduced.
- For Interface blocks the write is redirected to the parent Subsystem (with the direction flipped, since Interface input ↔ Subsystem output). The Interface itself derives its port names from the parent at read time, so custom labels propagate both ways automatically.
- Properties dialog gets a third view (alongside Properties / Python Code) — toggled via a `tag` icon in the header. Title swaps to "Port Labels", body shows one input per port with the default name as placeholder. Code view and Port-Labels view are mutually exclusive.
- Hidden for blocks whose port names are already driven by a regular param (Scope.labels, Spectrum.labels, Adder.operations, Divider.operations) — there the param is the single source of truth.
- Separator between input and output entries when both exist; spans full dialog width like other section separators.