### PR TITLE
Expand toolbox catalog with batt, flight, vehicle, rf

### DIFF
--- a/src/lib/toolbox/catalog.ts
+++ b/src/lib/toolbox/catalog.ts
@@ -41,6 +41,34 @@ export const TOOLBOX_CATALOG: CatalogEntry[] = [
 		importPath: 'pathsim_chem',
 		defaultCategory: 'Chemical',
 		preloaded: true
+	},
+	{
+		id: 'pathsim-batt',
+		displayName: 'pathsim-batt',
+		source: { type: 'pypi', pkg: 'pathsim-batt' },
+		importPath: 'pathsim_batt',
+		defaultCategory: 'Battery'
+	},
+	{
+		id: 'pathsim-flight',
+		displayName: 'pathsim-flight',
+		source: { type: 'pypi', pkg: 'pathsim-flight' },
+		importPath: 'pathsim_flight',
+		defaultCategory: 'Flight'
+	},
+	{
+		id: 'pathsim-vehicle',
+		displayName: 'pathsim-vehicle',
+		source: { type: 'pypi', pkg: 'pathsim-vehicle' },
+		importPath: 'pathsim_vehicle',
+		defaultCategory: 'Vehicle'
+	},
+	{
+		id: 'pathsim-rf',
+		displayName: 'pathsim-rf',
+		source: { type: 'pypi', pkg: 'pathsim-rf' },
+		importPath: 'pathsim_rf',
+		defaultCategory: 'RF'
 	}
 ];
 


### PR DESCRIPTION
Add the four existing pathsim org toolboxes to `TOOLBOX_CATALOG` so they show up in the Toolbox Manager catalog tab.

In the web runtime, batt and flight install their pure-Python parts only (heavy deps gated behind a `sys_platform != 'emscripten'` marker on the toolbox side); the existing installer error path already explains the desktop fallback if a wheel still can't load.