### PR TITLE
Add pathsim-fmi to toolbox catalog

### DIFF
--- a/src/lib/toolbox/catalog.ts
+++ b/src/lib/toolbox/catalog.ts
@@ -69,6 +69,13 @@ export const TOOLBOX_CATALOG: CatalogEntry[] = [
 		source: { type: 'pypi', pkg: 'pathsim-rf' },
 		importPath: 'pathsim_rf',
 		defaultCategory: 'RF'
+	},
+	{
+		id: 'pathsim-fmi',
+		displayName: 'pathsim-fmi',
+		source: { type: 'pypi', pkg: 'pathsim-fmi' },
+		importPath: 'pathsim_fmi',
+		defaultCategory: 'FMI'
 	}
 ];
 


### PR DESCRIPTION
FMI/FMU co-simulation toolbox. The package is installable on desktop runtimes; in the web runtime FMPy is gated behind a `sys_platform != 'emscripten'` marker and the toolbox's `__init__.py` skips the block re-exports when FMPy isn't available, so introspection reports an empty toolbox rather than classes that would fail at instantiation.