### PR TITLE
Engine + brand extension points (default pathsim/PathView unchanged)

### DIFF
--- a/scripts/capture-screenshots.js
+++ b/scripts/capture-screenshots.js
@@ -8,15 +8,23 @@
 
 import puppeteer from 'puppeteer-core';
 import { readFileSync, existsSync, mkdirSync } from 'fs';
-import { dirname, join } from 'path';
+import { dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const STATIC_DIR = join(__dirname, '..', 'static', 'examples');
-const SCREENSHOTS_DIR = join(STATIC_DIR, 'screenshots');
 const MANIFEST_PATH = join(STATIC_DIR, 'manifest.json');
 
-const BASE_URL = 'https://view.pathsim.org';
+// Where to write the PNGs. Override (SCREENSHOT_OUT_DIR) so a fastsim build can
+// capture straight into its build output instead of the default static dir.
+const SCREENSHOTS_DIR = process.env.SCREENSHOT_OUT_DIR
+	? resolve(process.env.SCREENSHOT_OUT_DIR)
+	: join(STATIC_DIR, 'screenshots');
+
+// Origin (+ base path) to screenshot. Defaults to the public blue pathview.
+// The fastsim build points this at a local `vite preview` of the red /app
+// build so the tiles match its styling (SCREENSHOT_BASE_URL=http://localhost:PORT/app).
+const BASE_URL = process.env.SCREENSHOT_BASE_URL || 'https://view.pathsim.org';
 const VIEWPORT = { width: 1000, height: 600 };
 const DEVICE_SCALE_FACTOR = 1;
 const SETTLE_DELAY = 5000;

--- a/src/lib/components/WelcomeModal.svelte
+++ b/src/lib/components/WelcomeModal.svelte
@@ -5,6 +5,7 @@
 	import { cubicOut } from 'svelte/easing';
 	import Icon from '$lib/components/icons/Icon.svelte';
 	import { PATHVIEW_VERSION, EXTRACTED_VERSIONS } from '$lib/constants/dependencies';
+	import { BRAND } from '$lib/constants/brand';
 	import { startGuidedTour, type TourId } from '$lib/tours';
 
 	interface Example {
@@ -102,8 +103,8 @@
 		</div>
 
 		<div class="header">
-			<img src="{base}/pathview_logo.png" alt="PathView" class="logo" />
-			<p class="tagline">Visual block-diagram editor for the PathSim simulation framework</p>
+			<img src="{base}/{BRAND.logo}" alt="{BRAND.name}" class="logo" />
+			<p class="tagline">Visual block-diagram editor for the {BRAND.framework} simulation framework</p>
 		</div>
 
 		<div class="actions">
@@ -112,7 +113,7 @@
 				<span class="action-label">New</span>
 			</button>
 
-			<a href="https://pathsim.org" target="_blank" class="action-card">
+			<a href={BRAND.home} target="_blank" class="action-card">
 				<Icon name="home" size={20} />
 				<span class="action-label">Home</span>
 			</a>

--- a/src/lib/constants/brand.ts
+++ b/src/lib/constants/brand.ts
@@ -1,0 +1,25 @@
+/**
+ * Visible product branding, configurable at build time.
+ *
+ * Defaults to PathView (PathSim blue). A re-branded distribution overrides any
+ * of these via `VITE_BRAND_*` env vars at build time, without touching the
+ * components that read them. `key` is set as `data-brand` on <html> so CSS can
+ * key an accent override off it; the JS accent (`accent` / `keywordColor`) feeds
+ * the canvas default color and the CodeMirror palette.
+ */
+export const BRAND = {
+	/** Short key, set as `data-brand` on <html> for CSS overrides. */
+	key: import.meta.env.VITE_BRAND_KEY || 'pathsim',
+	/** Display name (window title, logo alt, autosave prompt, welcome header). */
+	name: import.meta.env.VITE_BRAND_NAME || 'PathView',
+	/** Logo asset filename under static/. */
+	logo: import.meta.env.VITE_BRAND_LOGO || 'pathview_logo.png',
+	/** Primary accent (matches the CSS `--accent` default). */
+	accent: import.meta.env.VITE_BRAND_ACCENT || '#0070C0',
+	/** CodeMirror keyword color (control flow / imports). */
+	keywordColor: import.meta.env.VITE_BRAND_KEYWORD || '#E57373',
+	/** Home link target (welcome modal). */
+	home: import.meta.env.VITE_BRAND_HOME || 'https://pathsim.org',
+	/** Simulation framework name (welcome tagline). */
+	framework: import.meta.env.VITE_BRAND_FRAMEWORK || 'PathSim'
+};

--- a/src/lib/constants/engine.ts
+++ b/src/lib/constants/engine.ts
@@ -1,0 +1,34 @@
+/**
+ * Simulation engine selection.
+ *
+ * pathview generates Python that imports from the `pathsim` package tree. The
+ * engine is parameterised so a drop-in replacement with the same module layout
+ * (`<engine>`, `<engine>.blocks`, `<engine>.solvers`, `<engine>.events`) and
+ * class names can be selected at build time via the `VITE_ENGINE` env var.
+ *
+ * Defaults to `pathsim`, so an unconfigured build behaves exactly as before:
+ * `ENGINE_MODULE` is `pathsim` and `enginePath()` is the identity.
+ * (Uses the VITE_ prefix to match the repo's existing import.meta.env usage.)
+ */
+
+/** Active engine module name, fixed at build time. Defaults to pathsim. */
+export const ENGINE: string = import.meta.env.VITE_ENGINE || 'pathsim';
+
+/** Root import module for the active engine (alias of {@link ENGINE}). */
+export const ENGINE_MODULE: string = ENGINE;
+
+/**
+ * Map a `pathsim` package import path to the active engine's package tree.
+ *
+ * Core paths (`pathsim`, `pathsim.blocks`, `pathsim.solvers`, ...) are rewritten
+ * to the engine module; everything else (e.g. toolbox import paths like
+ * `pathsim_chem.blocks`) is left untouched. In the default pathsim build this is
+ * the identity function.
+ */
+export function enginePath(path: string): string {
+	if (ENGINE === 'pathsim') return path;
+	if (path === 'pathsim' || path.startsWith('pathsim.')) {
+		return ENGINE_MODULE + path.slice('pathsim'.length);
+	}
+	return path;
+}

--- a/src/lib/pyodide/backend/pyodide/backend.ts
+++ b/src/lib/pyodide/backend/pyodide/backend.ts
@@ -6,6 +6,7 @@
 import { get } from 'svelte/store';
 import type { BackendState, REPLRequest, REPLResponse, REPLErrorResponse } from '../types';
 import { AbstractBackend } from '../abstract';
+import { enginePreInit } from './engineHooks';
 import { backendState } from '../state';
 import { TIMEOUTS } from '$lib/constants/python';
 import { PROGRESS_MESSAGES, STATUS_MESSAGES } from '$lib/constants/messages';
@@ -82,8 +83,10 @@ export class PyodideBackend extends AbstractBackend {
 				}));
 			};
 
-			// Send init message
-			this.sendRequest({ type: 'init' });
+			// Engine pre-init seam (default no-op → null). An alternate engine
+			// can obtain an auth token here before the worker installs it.
+			const token = await enginePreInit();
+			this.sendRequest({ type: 'init', token });
 
 			// Wait for ready
 			await new Promise<void>((resolve, reject) => {

--- a/src/lib/pyodide/backend/pyodide/engineHooks.ts
+++ b/src/lib/pyodide/backend/pyodide/engineHooks.ts
@@ -1,0 +1,13 @@
+/**
+ * Engine hooks (main thread).
+ *
+ * `enginePreInit` runs right before the Pyodide worker is initialized. The
+ * default is a no-op that returns no token. A dedicated, stable seam so an
+ * alternate-engine build can swap *only* this module to, for example, obtain an
+ * auth token (and open a sign-in UI) before the engine install. The returned
+ * token is forwarded in the worker's `init` message and handed to the engine
+ * install seam ({@link ./engineInstall}).
+ */
+export async function enginePreInit(): Promise<string | null> {
+	return null;
+}

--- a/src/lib/pyodide/backend/pyodide/engineInstall.ts
+++ b/src/lib/pyodide/backend/pyodide/engineInstall.ts
@@ -1,0 +1,52 @@
+/**
+ * Engine install seam (worker side).
+ *
+ * Installs the simulation engine into the Pyodide runtime. The default is the
+ * configured PyPI packages (pathsim). This is a dedicated, stable seam so an
+ * alternate-engine build can swap *only* this module (e.g. to install a wasm
+ * wheel, optionally gated behind `ctx.token`) without touching the worker's
+ * lifecycle code. `PYODIDE_PRELOAD` is loaded by the caller before this runs.
+ */
+
+import { PYTHON_PACKAGES } from '$lib/constants/dependencies';
+import { PROGRESS_MESSAGES } from '$lib/constants/messages';
+import type { PyodideInterface } from 'https://cdn.jsdelivr.net/pyodide/v0.29.4/full/pyodide.mjs';
+
+export interface EngineInstallContext {
+	/** Emit a progress message to the UI. */
+	send: (msg: { type: 'progress'; value: string }) => void;
+	/** Auth token for a gated engine download (unused by the pathsim default). */
+	token?: string | null;
+}
+
+export async function installEngine(
+	pyodide: PyodideInterface,
+	ctx: EngineInstallContext
+): Promise<void> {
+	for (const pkg of PYTHON_PACKAGES) {
+		const progressKey = `INSTALLING_${pkg.import.toUpperCase()}` as keyof typeof PROGRESS_MESSAGES;
+		ctx.send({
+			type: 'progress',
+			value: PROGRESS_MESSAGES[progressKey] ?? `Installing ${pkg.import}...`
+		});
+
+		try {
+			const preFlag = pkg.pre ? ', pre=True' : '';
+			await pyodide.runPythonAsync(`
+import micropip
+await micropip.install('${pkg.pip}'${preFlag})
+			`);
+
+			// Verify installation
+			await pyodide.runPythonAsync(`
+import ${pkg.import}
+print(f"${pkg.import} {${pkg.import}.__version__} loaded successfully")
+			`);
+		} catch (error) {
+			if (pkg.required) {
+				throw new Error(`Failed to install required package ${pkg.pip}: ${error}`);
+			}
+			console.warn(`Optional package ${pkg.pip} failed to install:`, error);
+		}
+	}
+}

--- a/src/lib/pyodide/backend/pyodide/worker.ts
+++ b/src/lib/pyodide/backend/pyodide/worker.ts
@@ -3,13 +3,9 @@
  * Executes Python code via Pyodide in a separate thread
  */
 
-import {
-	PYODIDE_CDN_URL,
-	PYODIDE_PRELOAD,
-	PYTHON_PACKAGES,
-	type PackageConfig
-} from '$lib/constants/dependencies';
+import { PYODIDE_CDN_URL, PYODIDE_PRELOAD } from '$lib/constants/dependencies';
 import { PROGRESS_MESSAGES, ERROR_MESSAGES } from '$lib/constants/messages';
+import { installEngine } from './engineInstall';
 import type { REPLRequest, REPLResponse } from '../types';
 
 import type { PyodideInterface } from 'https://cdn.jsdelivr.net/pyodide/v0.29.4/full/pyodide.mjs';
@@ -29,7 +25,7 @@ function send(response: REPLResponse): void {
 /**
  * Initialize Pyodide and install packages
  */
-async function initialize(): Promise<void> {
+async function initialize(token?: string | null): Promise<void> {
 	if (isInitialized) {
 		send({ type: 'ready' });
 		return;
@@ -56,33 +52,9 @@ async function initialize(): Promise<void> {
 	send({ type: 'progress', value: PROGRESS_MESSAGES.INSTALLING_DEPS });
 	await pyodide.loadPackage([...PYODIDE_PRELOAD]);
 
-	// Install packages from config
-	for (const pkg of PYTHON_PACKAGES) {
-		const progressKey = `INSTALLING_${pkg.import.toUpperCase()}` as keyof typeof PROGRESS_MESSAGES;
-		send({
-			type: 'progress',
-			value: PROGRESS_MESSAGES[progressKey] ?? `Installing ${pkg.import}...`
-		});
-
-		try {
-			const preFlag = pkg.pre ? ', pre=True' : '';
-			await pyodide.runPythonAsync(`
-import micropip
-await micropip.install('${pkg.pip}'${preFlag})
-			`);
-
-			// Verify installation
-			await pyodide.runPythonAsync(`
-import ${pkg.import}
-print(f"${pkg.import} {${pkg.import}.__version__} loaded successfully")
-			`);
-		} catch (error) {
-			if (pkg.required) {
-				throw new Error(`Failed to install required package ${pkg.pip}: ${error}`);
-			}
-			console.warn(`Optional package ${pkg.pip} failed to install:`, error);
-		}
-	}
+	// Install the simulation engine (default: configured PyPI packages). The
+	// engineInstall seam lets an alternate-engine build swap this step.
+	await installEngine(pyodide, { send, token });
 
 	// Import numpy as np and gc globally
 	await pyodide.runPythonAsync(`import numpy as np`);
@@ -236,7 +208,7 @@ self.onmessage = async (event: MessageEvent<REPLRequest>) => {
 	try {
 		switch (type) {
 			case 'init':
-				await initialize();
+				await initialize('token' in event.data ? event.data.token : undefined);
 				break;
 
 			case 'exec':

--- a/src/lib/pyodide/backend/types.ts
+++ b/src/lib/pyodide/backend/types.ts
@@ -11,7 +11,7 @@
  * Request messages (main thread → backend)
  */
 export type REPLRequest =
-	| { type: 'init' }
+	| { type: 'init'; token?: string | null }
 	| { type: 'exec'; id: string; code: string }
 	| { type: 'eval'; id: string; expr: string }
 	| { type: 'stream-start'; id: string; expr: string }

--- a/src/lib/pyodide/pathsimRunner.ts
+++ b/src/lib/pyodide/pathsimRunner.ts
@@ -12,6 +12,7 @@ import { NODE_TYPES } from '$lib/constants/nodeTypes';
 import { BLOCK_CATEGORY_ORDER } from '$lib/constants/python';
 import { isSubsystem, isInterface } from '$lib/nodes/shapes';
 import { blockImportPaths } from '$lib/nodes/generated/blocks';
+import { ENGINE_MODULE, enginePath } from '$lib/constants/engine';
 import { graphStore, findParentSubsystem } from '$lib/stores/graph';
 import {
 	runStreamingSimulation,
@@ -165,8 +166,11 @@ function collectBlockImportGroups(nodes: NodeInstance[]): Map<string, Set<string
 
 		// Toolbox-registered blocks carry their own importPath; built-ins
 		// fall back to the static map. Last fallback is core pathsim.blocks.
-		const importPath =
-			typeDef.importPath ?? blockImportPaths[typeDef.blockClass] ?? 'pathsim.blocks';
+		// enginePath() rewrites core pathsim paths to the active engine module
+		// (identity in the default pathsim build).
+		const importPath = enginePath(
+			typeDef.importPath ?? blockImportPaths[typeDef.blockClass] ?? 'pathsim.blocks'
+		);
 		if (!groups.has(importPath)) groups.set(importPath, new Set());
 		groups.get(importPath)!.add(typeDef.blockClass);
 	}
@@ -395,9 +399,9 @@ export function generatePythonCode(
 	lines.push('# IMPORTS');
 	lines.push('import numpy as np');
 	if (hasSubsystems) {
-		lines.push('from pathsim import Simulation, Connection, Subsystem, Interface');
+		lines.push(`from ${ENGINE_MODULE} import Simulation, Connection, Subsystem, Interface`);
 	} else {
-		lines.push('from pathsim import Simulation, Connection');
+		lines.push(`from ${ENGINE_MODULE} import Simulation, Connection`);
 	}
 	for (const [importPath, classes] of importGroups) {
 		const sorted = [...classes].sort();
@@ -408,12 +412,12 @@ export function generatePythonCode(
 		}
 	}
 	// Ensure at least pathsim.blocks is imported even if no blocks
-	if (!importGroups.has('pathsim.blocks')) {
-		lines.push('from pathsim.blocks import *');
+	if (!importGroups.has(`${ENGINE_MODULE}.blocks`)) {
+		lines.push(`from ${ENGINE_MODULE}.blocks import *`);
 	}
-	lines.push(`from pathsim.solvers import ${getSettingOrDefault(settings, 'solver')}`);
+	lines.push(`from ${ENGINE_MODULE}.solvers import ${getSettingOrDefault(settings, 'solver')}`);
 	if (hasEvents) {
-		lines.push(`from pathsim.events import ${[...eventClasses].join(', ')}`);
+		lines.push(`from ${ENGINE_MODULE}.events import ${[...eventClasses].join(', ')}`);
 	}
 	lines.push('');
 
@@ -566,9 +570,9 @@ function generateFormattedPythonCode(
 	lines.push('import matplotlib.pyplot as plt');
 	lines.push('');
 	if (hasSubsystems) {
-		lines.push('from pathsim import Simulation, Connection, Subsystem, Interface');
+		lines.push(`from ${ENGINE_MODULE} import Simulation, Connection, Subsystem, Interface`);
 	} else {
-		lines.push('from pathsim import Simulation, Connection');
+		lines.push(`from ${ENGINE_MODULE} import Simulation, Connection`);
 	}
 
 	// Collect block classes grouped by import path
@@ -589,9 +593,9 @@ function generateFormattedPythonCode(
 		}
 	}
 
-	lines.push(`from pathsim.solvers import ${getSettingOrDefault(settings, 'solver')}`);
+	lines.push(`from ${ENGINE_MODULE}.solvers import ${getSettingOrDefault(settings, 'solver')}`);
 	if (hasEvents) {
-		lines.push(`from pathsim.events import ${[...eventClasses].join(', ')}`);
+		lines.push(`from ${ENGINE_MODULE}.events import ${[...eventClasses].join(', ')}`);
 	}
 	lines.push('');
 

--- a/src/lib/pyodide/pythonHelpers.ts
+++ b/src/lib/pyodide/pythonHelpers.ts
@@ -22,6 +22,16 @@ def _to_json(obj):
         return obj.decode('utf-8', errors='replace')
     return obj
 
+def _block_key(b):
+    """Stable identity for a block, robust across engine wrappers.
+
+    fastsim re-wraps a block on every Rust-to-Python access (e.g.
+    subsystem.blocks), so Python id() is NOT stable; it exposes a stable
+    block_id (the underlying pointer). pathsim has no block_id, so fall back
+    to id(). Keying maps on this keeps subsystem-nested scopes mappable.
+    """
+    return getattr(b, 'block_id', None) or id(b)
+
 def _step_streaming_gen():
     """Step the streaming generator and return result dict."""
     global _sim_streaming, _sim_gen
@@ -65,14 +75,14 @@ def _apply_single_mutation(mut):
         g[mut['var']] = block
         sim.add_block(block)
         blocks.append(block)
-        _node_id_map[id(block)] = mut['nodeId']
+        _node_id_map[_block_key(block)] = mut['nodeId']
         _node_name_map[mut['nodeId']] = mut['nodeName']
 
     elif t == 'remove_block':
         block = g[mut['var']]
         sim.remove_block(block)
         blocks.remove(block)
-        _node_id_map.pop(id(block), None)
+        _node_id_map.pop(_block_key(block), None)
         _node_name_map.pop(mut['nodeId'], None)
 
     elif t == 'add_connection':
@@ -101,8 +111,11 @@ def _extract_scope_data(blocks, node_id_map, incremental=False):
 
     def find_scopes(block_list):
         for block in block_list:
-            block_name = type(block).__name__
-            block_id = node_id_map.get(id(block), str(id(block)))
+            # Prefer the engine's type_name: fastsim blocks are all of Python
+            # type "Block" and carry the real kind in .type_name; pathsim blocks
+            # have no type_name, so fall back to the class name.
+            block_name = getattr(block, 'type_name', None) or type(block).__name__
+            block_id = node_id_map.get(_block_key(block), str(_block_key(block)))
 
             if block_name == 'Scope':
                 try:
@@ -131,8 +144,11 @@ def _extract_spectrum_data(blocks, node_id_map):
 
     def find_spectrums(block_list):
         for block in block_list:
-            block_name = type(block).__name__
-            block_id = node_id_map.get(id(block), str(id(block)))
+            # Prefer the engine's type_name: fastsim blocks are all of Python
+            # type "Block" and carry the real kind in .type_name; pathsim blocks
+            # have no type_name, so fall back to the class name.
+            block_name = getattr(block, 'type_name', None) or type(block).__name__
+            block_id = node_id_map.get(_block_key(block), str(_block_key(block)))
 
             if block_name == 'Spectrum':
                 try:

--- a/src/lib/toolbox/dependencies.ts
+++ b/src/lib/toolbox/dependencies.ts
@@ -11,11 +11,26 @@
 import { get } from 'svelte/store';
 import { nodeRegistry, BUILTIN_SOURCE } from '$lib/nodes/registry';
 import { NODE_TYPES } from '$lib/constants/nodeTypes';
+import { ENGINE_MODULE } from '$lib/constants/engine';
 import type { NodeInstance } from '$lib/types/nodes';
 import type { ToolboxRequirement } from '$lib/types/schema';
 import { toolboxes } from './store';
 import { toolboxSourceKey } from './identity';
 import type { ToolboxConfig } from './types';
+
+// The simulation engine itself (pathsim / fastsim) is never a toolbox — it is
+// always present. A stale autosave or a file saved under the other engine can
+// still carry the engine as a `requiredToolbox`; trying to micropip-install it
+// fails ("Invalid wheel filename: 'fastsim'"). Treat these names as reserved
+// and skip them at load time. Real toolboxes (e.g. pathsim-chem -> pkg
+// `pathsim-chem`, importPath `pathsim_chem`) never match these exact names.
+const ENGINE_MODULES = new Set(['pathsim', 'fastsim', ENGINE_MODULE]);
+
+function isEngineRequirement(r: ToolboxRequirement): boolean {
+	const s = (r.source ?? {}) as { pkg?: string; url?: string };
+	const candidates = [r.importPath, r.id, s.pkg, s.url].filter(Boolean).map(String);
+	return candidates.some((c) => ENGINE_MODULES.has(c) || ENGINE_MODULES.has(c.replace(/-/g, '_')));
+}
 
 function walkNodeTypes(nodes: NodeInstance[], out: Set<string>): void {
 	for (const node of nodes) {
@@ -57,7 +72,8 @@ export function collectRequiredToolboxes(nodes: NodeInstance[]): ToolboxRequirem
 		const t = installed.find((tb) => tb.id === id);
 		if (t) result.push(toRequirement(t));
 	}
-	return result;
+	// Never persist the engine itself as a requirement (see isEngineRequirement).
+	return result.filter((r) => !isEngineRequirement(r));
 }
 
 /**
@@ -74,5 +90,5 @@ export function collectRequiredToolboxes(nodes: NodeInstance[]): ToolboxRequirem
 export function findMissingRequirements(reqs: ToolboxRequirement[]): ToolboxRequirement[] {
 	if (!reqs || reqs.length === 0) return [];
 	const installedKeys = new Set(get(toolboxes).map((t) => toolboxSourceKey(t.source)));
-	return reqs.filter((r) => !installedKeys.has(toolboxSourceKey(r.source)));
+	return reqs.filter((r) => !isEngineRequirement(r) && !installedKeys.has(toolboxSourceKey(r.source)));
 }

--- a/src/lib/utils/codemirror.ts
+++ b/src/lib/utils/codemirror.ts
@@ -2,14 +2,17 @@
  * Shared CodeMirror utilities for consistent editor setup across the app.
  */
 
-// Syntax highlighting colors - aligned with node color palette
+import { BRAND } from '$lib/constants/brand';
+
+// Syntax highlighting colors - aligned with node color palette. keyword and the
+// operator/function accent follow the active brand (defaults: red + PathSim blue).
 export const SYNTAX_COLORS = {
-	keyword: '#E57373',   // Red - control flow, imports
-	operator: '#0070C0', // PathSim blue - symbols, operators
+	keyword: BRAND.keywordColor,   // control flow, imports
+	operator: BRAND.accent, // brand accent - symbols, operators
 	special: '#FFB74D',  // Orange - classes, types, decorators
 	number: '#4DB6AC',   // Teal - numeric literals
 	string: '#81C784',   // Green - string literals
-	function: '#0070C0', // PathSim blue - function names
+	function: BRAND.accent, // brand accent - function names
 	comment: { dark: '#505060', light: '#909098' },  // Same as line numbers
 	invalid: '#BA68C8',  // Purple - errors
 	// Theme-specific values for variables and punctuation

--- a/src/lib/utils/colors.ts
+++ b/src/lib/utils/colors.ts
@@ -2,8 +2,11 @@
  * Color definitions for PathView
  */
 
-// Default node/event color (matches --pathsim-blue CSS variable)
-export const DEFAULT_NODE_COLOR = '#0070C0';
+import { BRAND } from '$lib/constants/brand';
+
+// Default node/event/annotation color: the brand accent (matches the CSS
+// `--accent` default). Items without an explicit color follow the active brand.
+export const DEFAULT_NODE_COLOR = BRAND.accent;
 
 // Port colors
 export const PORT_COLORS = {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import '../app.css';
+	import { BRAND } from '$lib/constants/brand';
 
 	interface Props {
 		children: import('svelte').Snippet;
 	}
 
 	let { children }: Props = $props();
+
+	// Drive the CSS accent override (data-brand) for the active build's brand.
+	// Set on hydration (synchronously, not onMount) to minimize any flash.
+	if (typeof document !== 'undefined') {
+		document.documentElement.dataset.brand = BRAND.key;
+	}
 
 	// whatsmytraffic-Analytics nur auf der Web-Version (view.pathsim.org),
 	// nicht in der Standalone-/pip-Version.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -31,6 +31,7 @@
 	import Icon from '$lib/components/icons/Icon.svelte';
 	import { nodeRegistry } from '$lib/nodes';
 	import { NODE_TYPES } from '$lib/constants/nodeTypes';
+	import { BRAND } from '$lib/constants/brand';
 	import { PANEL_GAP, PANEL_TOGGLES_WIDTH, MIN_BOTTOM_PANEL_WIDTH, PANEL_DEFAULTS, NAV_HEIGHT } from '$lib/constants/layout';
 	import { GRID_SIZE } from '$lib/constants/grid';
 	import { DEFAULT_SIMULATION_SETTINGS } from '$lib/nodes/types';
@@ -734,7 +735,7 @@
 			if (!snapshot || urlModelConfig) return;
 			const ok = await confirmationStore.show({
 				title: 'Restore last session?',
-				message: 'PathView found an autosaved version of your last session. Restore it?',
+				message: `${BRAND.name} found an autosaved version of your last session. Restore it?`,
 				confirmText: 'Restore',
 				cancelText: 'Discard'
 			});
@@ -1300,14 +1301,14 @@
 <svelte:window onkeydown={handleKeydown} onresize={handleWindowResize} onmousemove={(e) => mousePosition = { x: e.clientX, y: e.clientY }} />
 
 <svelte:head>
-	<title>PathView</title>
+	<title>{BRAND.name}</title>
 	<link rel="icon" type="image/png" href="{base}/favicon.png">
 </svelte:head>
 
 <div class="app">
 	<!-- Logo overlay in top left -->
 	<button class="logo-overlay" onclick={() => showWelcomeModal = true} use:tooltip={"Welcome"} aria-label="Welcome" data-tour="welcome-banner-logo">
-		<img src="{base}/pathview_logo.png" alt="PathView" />
+		<img src="{base}/{BRAND.logo}" alt="{BRAND.name}" />
 	</button>
 
 	<!-- Canvas takes full screen -->


### PR DESCRIPTION
Make pathview engine- and brand-parametric via small, generic seams. **All defaults are unchanged** (pathsim engine, PathView/blue brand), so the public and standalone builds behave exactly as before; a downstream/re-branded build configures via env + swaps a couple of seam modules.

- **`constants/engine.ts`**: `ENGINE`/`ENGINE_MODULE`/`enginePath()` (default `pathsim`, `VITE_ENGINE` override). Codegen (`pathsimRunner.ts`) imports from `${ENGINE_MODULE}` and maps core paths via `enginePath()` (identity for pathsim).
- **`constants/brand.ts`**: env-driven `BRAND` (name/logo/accent/keyword/home/framework, default PathView/blue). `+layout` sets `data-brand`; `colors.ts`/`codemirror.ts`/`+page`/`WelcomeModal` read it.
- **Engine seams**: `engineInstall.ts` (`installEngine`, default = configured PyPI packages) + `engineHooks.ts` (`enginePreInit`, default no-op). Worker/backend call these so an alternate engine swaps only the seam.
- **Generic hardening**: stable `_block_key`/`type_name` (fallback to `id()`/`__name__`), never install the engine itself as a toolbox, `SCREENSHOT_BASE_URL`/`SCREENSHOT_OUT_DIR` env hooks for the screenshot script.

`npm run check` clean; `vite build` succeeds.