### PR TITLE
Disable Plotly reset-axes tip popup

### DIFF
--- a/src/lib/plotting/core/constants.ts
+++ b/src/lib/plotting/core/constants.ts
@@ -107,6 +107,8 @@ export const MARKER_SYMBOL_PLOTLY: Record<MarkerStyle, string> = {
 export const PLOTLY_CONFIG: Partial<Plotly.Config> = {
 	responsive: true,
 	displaylogo: false,
+	// Suppress Plotly's "Double-click to zoom back out" / reset-axes tip popup.
+	showTips: false,
 	displayModeBar: 'hover',
 	modeBarButtonsToRemove: ['lasso2d', 'select2d'],
 	modeBarButtonsToAdd: [],


### PR DESCRIPTION
Sets `showTips: false` in PLOTLY_CONFIG to suppress Plotly's transient "Double-click to zoom back out"/reset-axes tip. npm run check clean.