### PR TITLE
Hide backend-incompatible block categories on Pyodide

### DIFF
--- a/src/lib/components/panels/NodeLibrary.svelte
+++ b/src/lib/components/panels/NodeLibrary.svelte
@@ -2,6 +2,8 @@
 	import { onDestroy } from 'svelte';
 	import { nodeRegistry, blockConfig, registryVersion, type NodeCategory, type NodeTypeDefinition } from '$lib/nodes';
 	import { NODE_TYPES } from '$lib/constants/nodeTypes';
+	import { PYODIDE_HIDDEN_CATEGORIES } from '$lib/constants/python';
+	import { getBackendType } from '$lib/pyodide/backend';
 	import { createHoverDetail } from '$lib/actions/hoverDetail.svelte';
 	import NodePreview from '$lib/components/nodes/NodePreview.svelte';
 	import Icon from '$lib/components/icons/Icon.svelte';
@@ -70,6 +72,13 @@
 		// Touch the tick to register the dependency
 		void registryTick;
 		let nodes = nodeRegistry.getAll().filter((node) => node.type !== NODE_TYPES.INTERFACE);
+
+		// Hide backend-incompatible categories (e.g. FMI on the Pyodide backend:
+		// FMU blocks need the native FMI runtime, not available in the browser).
+		if (getBackendType() === 'pyodide' && PYODIDE_HIDDEN_CATEGORIES.length > 0) {
+			const hidden = new Set(PYODIDE_HIDDEN_CATEGORIES);
+			nodes = nodes.filter((node) => !hidden.has(node.category));
+		}
 
 		if (!searchQuery.trim()) return nodes;
 		const query = searchQuery.toLowerCase();

--- a/src/lib/constants/python.ts
+++ b/src/lib/constants/python.ts
@@ -27,12 +27,28 @@ export const CODE_SECTIONS = {
 export const BLOCK_CATEGORY_ORDER: string[] = [
 	'Sources',
 	'Dynamic',
+	'DAE',
 	'Algebraic',
 	'Logic',
 	'Discrete',
+	'FMI',
 	'Recording',
 	'Subsystem'
 ];
+
+/**
+ * Block categories hidden when running on the Pyodide (in-browser) backend,
+ * configurable per distribution via `VITE_PYODIDE_HIDDEN_CATEGORIES`
+ * (comma-separated). Empty by default. Use this for categories whose blocks
+ * can't work in the browser sandbox (e.g. FMI/FMU blocks that drive an external
+ * .fmu through a native runtime) so they're only offered on a native backend.
+ */
+export const PYODIDE_HIDDEN_CATEGORIES: string[] = (
+	(import.meta.env.VITE_PYODIDE_HIDDEN_CATEGORIES as string | undefined) ?? ''
+)
+	.split(',')
+	.map((c) => c.trim())
+	.filter(Boolean);
 
 /**
  * Timeout constants for Pyodide operations (in milliseconds)


### PR DESCRIPTION
Some block categories can't work in the browser sandbox (e.g. FMI/FMU blocks that drive an external `.fmu` through a native runtime) but are fine on a native backend (Flask/remote). There was no way to keep them out of the in-browser Block Library.

- `PYODIDE_HIDDEN_CATEGORIES` (in `constants/python.ts`): parsed from `VITE_PYODIDE_HIDDEN_CATEGORIES` (comma-separated), **empty by default** — no behaviour change for the default build.
- `NodeLibrary.svelte`: when the active backend is `pyodide`, filters out nodes whose category is in that set.
- `BLOCK_CATEGORY_ORDER`: adds `DAE` and `FMI` to the display order (inert when no blocks use them).

A distribution that ships browser-incompatible categories (e.g. an engine with FMI blocks) sets `VITE_PYODIDE_HIDDEN_CATEGORIES=FMI` and the category is offered only on a native backend. `svelte-check`: 0 errors/0 warnings.