### PR TITLE
Codegen: engine setup seam + consistent _block_key

### DIFF
--- a/src/lib/pyodide/engineCodegen.ts
+++ b/src/lib/pyodide/engineCodegen.ts
@@ -1,0 +1,32 @@
+/**
+ * Engine-specific codegen seam.
+ *
+ * Lets an alternate-engine build inject setup code into the generated Python
+ * *after* the imports and *before* the blocks, without touching the shared
+ * code generation in pathsimRunner.ts. The default engine (pathsim) needs none,
+ * so this is a no-op that a re-engined build swaps out (like the worker-side
+ * engineInstall seam).
+ *
+ * Example (fastsim): emit class-level `port()` wraps for toolbox block classes,
+ * because fastsim's `Connection` only accepts fastsim blocks, so a pathsim
+ * toolbox block must be ported at the class level before any instance is built.
+ */
+
+/** A named block of setup lines emitted after imports, before block creation. */
+export interface EngineSetup {
+	/** Section header, rendered as a `# <header>` comment (with a banner on export). */
+	header: string;
+	/** Python source lines for the section body. */
+	lines: string[];
+}
+
+/**
+ * Engine-specific setup code, given the block import groups (import path → class
+ * names) collected from the graph. Returns null when the engine needs no setup
+ * (the default), in which case no section is emitted.
+ */
+export function generateEngineSetup(
+	_importGroups: Map<string, Set<string>>
+): EngineSetup | null {
+	return null;
+}

--- a/src/lib/pyodide/pathsimRunner.ts
+++ b/src/lib/pyodide/pathsimRunner.ts
@@ -13,6 +13,7 @@ import { BLOCK_CATEGORY_ORDER } from '$lib/constants/python';
 import { isSubsystem, isInterface } from '$lib/nodes/shapes';
 import { blockImportPaths } from '$lib/nodes/generated/blocks';
 import { ENGINE_MODULE, enginePath } from '$lib/constants/engine';
+import { generateEngineSetup } from './engineCodegen';
 import { graphStore, findParentSubsystem } from '$lib/stores/graph';
 import {
 	runStreamingSimulation,
@@ -421,6 +422,14 @@ export function generatePythonCode(
 	}
 	lines.push('');
 
+	// 1b. Engine-specific setup (e.g. fastsim port() wraps); no-op by default.
+	const engineSetup = generateEngineSetup(importGroups);
+	if (engineSetup) {
+		lines.push(`# ${engineSetup.header}`);
+		lines.push(...engineSetup.lines);
+		lines.push('');
+	}
+
 	// 2. Code context (user-defined variables/functions)
 	if (codeContext.trim()) {
 		lines.push('# CODE CONTEXT');
@@ -475,7 +484,10 @@ export function generatePythonCode(
 		lines.push('# NODE ID MAPPING (for data extraction)');
 		lines.push('_node_id_map = {');
 		for (const [nodeId, varName] of nodeVars) {
-			lines.push(`    id(${varName}): "${nodeId}",`);
+			// _block_key (REPL setup) uses the engine's stable block_id when
+			// present and falls back to id(), so static entries here stay
+			// consistent with the mutation-added ones in _apply_mutations.
+			lines.push(`    _block_key(${varName}): "${nodeId}",`);
 		}
 		lines.push('}');
 		lines.push('');
@@ -598,6 +610,17 @@ function generateFormattedPythonCode(
 		lines.push(`from ${ENGINE_MODULE}.events import ${[...eventClasses].join(', ')}`);
 	}
 	lines.push('');
+
+	// Engine-specific setup (e.g. fastsim port() wraps); no-op by default.
+	const engineSetup = generateEngineSetup(importGroups);
+	if (engineSetup) {
+		lines.push(divider);
+		lines.push(`# ${engineSetup.header}`);
+		lines.push(divider);
+		lines.push('');
+		lines.push(...engineSetup.lines);
+		lines.push('');
+	}
 
 	// Code context (user-defined variables/functions)
 	if (codeContext.trim()) {


### PR DESCRIPTION
Two related codegen cleanups, no behaviour change for the default (pathsim) build.

**1. Engine codegen seam.** New `engineCodegen.ts` exports `generateEngineSetup(importGroups)`, returning `null` by default (no extra code). `pathsimRunner.ts` calls it right after the imports in both the runtime and the export generators; when non-null it emits a `# <header>` section (banner on export) with the engine's setup lines. This is the codegen counterpart to the worker-side `engineInstall` seam: an alternate engine can inject setup (e.g. class-level `port()` wraps for toolbox blocks) without forking the shared codegen.

**2. Consistent block identity.** The generated `_node_id_map` keyed on raw `id(var)`, while `_apply_mutations` (dynamic add/remove) and the scope/spectrum extraction already key on `_block_key(...)`. `_block_key` returns a stable `block_id` when the engine exposes one and falls back to `id()` otherwise — so for pathsim this is identical, but it removes the static/dynamic inconsistency (a latent bug for any engine where `id()` isn't stable across wrappers).

`svelte-check`: 0 errors/0 warnings.