### PR TITLE
Surface recorder read failures on stderr

### DIFF
--- a/src/lib/pyodide/pythonHelpers.ts
+++ b/src/lib/pyodide/pythonHelpers.ts
@@ -129,7 +129,9 @@ def _extract_scope_data(blocks, node_id_map, incremental=False):
                             'labels': labels
                         }
                 except Exception as e:
-                    print(f"Error reading Scope: {e}")
+                    # stderr (not stdout) so a failing recorder surfaces as an
+                    # error in the console instead of an unexplained empty plot.
+                    print(f"Error reading Scope: {e}", file=__import__('sys').stderr)
             elif block_name == 'Subsystem':
                 if hasattr(block, 'blocks'):
                     find_scopes(block.blocks)
@@ -177,7 +179,9 @@ def _extract_spectrum_data(blocks, node_id_map):
                             'labels': labels
                         }
                 except Exception as e:
-                    print(f"Error reading Spectrum: {e}")
+                    # stderr (not stdout) so a failing recorder surfaces as an
+                    # error in the console instead of an unexplained empty plot.
+                    print(f"Error reading Spectrum: {e}", file=__import__('sys').stderr)
             elif block_name == 'Subsystem':
                 if hasattr(block, 'blocks'):
                     find_spectrums(block.blocks)


### PR DESCRIPTION
When a Scope/Spectrum block's `read()` threw during extraction, the error was `print()`ed to **stdout** and swallowed — the plot just came back empty with no indication why. This routes both to **stderr** (matching `_apply_mutations`), so the worker surfaces it as a console error and an empty plot is explainable.

Two-line change in the extraction helpers; no behaviour change otherwise. `svelte-check`: 0 errors/0 warnings.