### PR TITLE
Extract commitToolbox() shared commit step

### DIFF
--- a/src/lib/components/dialogs/ToolboxManagerDialog.svelte
+++ b/src/lib/components/dialogs/ToolboxManagerDialog.svelte
@@ -8,9 +8,8 @@
 		TOOLBOX_CATALOG,
 		performInstall,
 		discoverToolbox,
-		registerToolbox,
+		commitToolbox,
 		uninstallToolbox,
-		upsertToolbox,
 		removeToolbox,
 		toolboxes,
 		toolboxSourceKey,
@@ -318,13 +317,10 @@
 			blocks: blockSelections,
 			events: eventSelections
 		};
-		registerToolbox(config, {
-			blocks: discoveredBlocks,
-			events: discoveredEvents,
+		commitToolbox(config, { blocks: discoveredBlocks, events: discoveredEvents }, {
 			defaultCategory,
 			categoryByClass
 		});
-		upsertToolbox(config);
 		onSaved?.(config);
 		onClose();
 	}

--- a/src/lib/toolbox/index.ts
+++ b/src/lib/toolbox/index.ts
@@ -27,6 +27,7 @@ export {
 	performInstall,
 	discoverToolbox,
 	registerToolbox,
+	commitToolbox,
 	uninstallToolbox
 } from './register';
 

--- a/src/lib/toolbox/installFlow.ts
+++ b/src/lib/toolbox/installFlow.ts
@@ -11,8 +11,8 @@
  */
 
 import { get } from 'svelte/store';
-import { toolboxes, upsertToolbox } from './store';
-import { performInstall, discoverToolbox, registerToolbox } from './register';
+import { toolboxes } from './store';
+import { performInstall, discoverToolbox, commitToolbox } from './register';
 import { getCatalogEntry } from './catalog';
 import type { ToolboxConfig, ToolboxSource } from './types';
 
@@ -65,13 +65,10 @@ export async function installAndRegisterToolbox(spec: InstallSpec): Promise<Tool
 		};
 
 		const catalog = getCatalogEntry(spec.id);
-		registerToolbox(config, {
-			blocks: discovered.blocks,
-			events: discovered.events,
+		commitToolbox(config, discovered, {
 			defaultCategory: catalog?.defaultCategory,
 			categoryByClass: catalog?.categoryByClass
 		});
-		upsertToolbox(config);
 
 		return config;
 	})();

--- a/src/lib/toolbox/register.ts
+++ b/src/lib/toolbox/register.ts
@@ -25,6 +25,7 @@ import {
 	type IntrospectedBlock,
 	type IntrospectedEvent
 } from './installer';
+import { upsertToolbox } from './store';
 import type { BlockSelection, EventSelection, ToolboxConfig } from './types';
 
 /**
@@ -245,6 +246,26 @@ export function registerToolbox(
 		const def = buildEventDefinition(event, sel, importPath);
 		eventRegistry.register(def, config.id);
 	}
+}
+
+/**
+ * Commit a discovered toolbox: register its selected blocks/events and persist
+ * the config. The shared tail of both install paths — the startup/required
+ * orchestrator (`installFlow`) and the manager dialog — which run their own
+ * install + discover + selection beforehand and then call this to land it.
+ */
+export function commitToolbox(
+	config: ToolboxConfig,
+	discovered: { blocks: IntrospectedBlock[]; events: IntrospectedEvent[] },
+	hints: { defaultCategory?: string; categoryByClass?: Record<string, string> } = {}
+): void {
+	registerToolbox(config, {
+		blocks: discovered.blocks,
+		events: discovered.events,
+		defaultCategory: hints.defaultCategory,
+		categoryByClass: hints.categoryByClass
+	});
+	upsertToolbox(config);
 }
 
 /** Clean up a toolbox: drop registry entries and the Python module. */


### PR DESCRIPTION
The install orchestrator (`installFlow`) and the manager dialog both finish an install the same way — `registerToolbox(config, {blocks, events, defaultCategory, categoryByClass})` then `upsertToolbox(config)` — duplicated in two places that could drift.

Extracts `commitToolbox(config, discovered, hints)` in `register.ts` and routes both call sites through it. The two paths still run their own install + discover + selection beforehand (the dialog interactively, installFlow automatically); only the shared "register selected + persist" tail is unified.

`svelte-check`: 0 errors/0 warnings.