### PR TITLE
Rework block icons

### DIFF
--- a/src/lib/components/icons/BlockIcon.svelte
+++ b/src/lib/components/icons/BlockIcon.svelte
@@ -24,6 +24,7 @@
 	import IconGlyph from './blocks/IconGlyph.svelte';
 	import IconScope from './blocks/IconScope.svelte';
 	import IconSurface from './blocks/IconSurface.svelte';
+	import IconPoleZero from './blocks/IconPoleZero.svelte';
 
 	interface Props {
 		blockClass: string | undefined;
@@ -46,7 +47,12 @@
 				axes={def.axes}
 				markers={def.markers}
 				decoration={def.decoration}
+				asymptotes={def.asymptotes}
+				badge={def.badge}
+				stems={def.stems}
 			/>
+		{:else if def.kind === 'pz'}
+			<IconPoleZero poles={def.poles} zeros={def.zeros} />
 		{:else if def.kind === 'scope'}
 			<IconScope
 				samples={def.samples()}

--- a/src/lib/components/icons/BlockIcon.svelte
+++ b/src/lib/components/icons/BlockIcon.svelte
@@ -60,6 +60,7 @@
 				yRange={def.yRange}
 				gridX={def.gridX}
 				gridY={def.gridY}
+				bars={def.bars}
 			/>
 		{:else if def.kind === 'surface'}
 			<IconSurface fn={def.fn} rows={def.rows} cols={def.cols} />

--- a/src/lib/components/icons/blocks/IconPlot.svelte
+++ b/src/lib/components/icons/blocks/IconPlot.svelte
@@ -101,15 +101,16 @@
 		<path d="M 86 22 L 86 44 M 82 40 L 86 44 L 90 40" />
 	{/if}
 	{#if badge}
+		<!-- Top-left: the corner a rising characteristic leaves free. -->
 		<text
-			x={AXIS_BOX.x1}
-			y={AXIS_BOX.y0 + 2}
-			text-anchor="end"
+			x={AXIS_BOX.x0 + 4}
+			y={AXIS_BOX.y0}
+			text-anchor="start"
 			dominant-baseline="hanging"
 			fill="currentColor"
 			stroke="none"
 			font-family="ui-monospace, 'JetBrains Mono', 'SF Mono', Menlo, monospace"
-			font-size="15"
+			font-size="11"
 			font-weight="600">{badge}</text
 		>
 	{/if}

--- a/src/lib/components/icons/blocks/IconPlot.svelte
+++ b/src/lib/components/icons/blocks/IconPlot.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { AXIS_BOX, mapX, mapY, buildPath, type Sample } from './curves';
+	import { AXIS_BOX, PLOT_BOX, mapX, mapY, buildPath, type Sample } from './curves';
 
 	type AxesMode = 'none' | 'baseline' | 'cross';
 	type Decoration = 'arrow-up' | 'arrow-down';
@@ -12,6 +12,10 @@
 		axes?: AxesMode;
 		markers?: boolean;
 		decoration?: Decoration;
+		/** Vertical asymptotes in sample-x coordinates, drawn dashed. */
+		asymptotes?: number[];
+		/** Small superscript label in the top-right corner (e.g. base of a log). */
+		badge?: string;
 	}
 
 	let {
@@ -21,7 +25,9 @@
 		yRange = [0, 1],
 		axes = 'cross',
 		markers = false,
-		decoration
+		decoration,
+		asymptotes,
+		badge
 	}: Props = $props();
 
 	const path = $derived(buildPath(samples, xRange[0], xRange[1], yRange[0], yRange[1]));
@@ -31,26 +37,40 @@
 			: ''
 	);
 
+	// The zero line only sits inside the plot when 0 is actually part of the
+	// value range; otherwise it falls back to the box edge. For x this uses a
+	// strict test, so a time signal (x starting at 0) keeps its y-axis just
+	// left of the trace instead of drawing it straight through the first edge.
 	const xAxisY = $derived(
 		yRange[0] <= 0 && yRange[1] >= 0 ? mapY(0, yRange[0], yRange[1]) : AXIS_BOX.y1
 	);
 	const yAxisX = $derived(
-		xRange[0] <= 0 && xRange[1] >= 0 ? mapX(0, xRange[0], xRange[1]) : AXIS_BOX.x0
+		xRange[0] < 0 && xRange[1] > 0 ? mapX(0, xRange[0], xRange[1]) : AXIS_BOX.x0
 	);
 
 	const finiteSamples = $derived(samples.filter(([, v]) => Number.isFinite(v)));
+	const asymptoteX = $derived(
+		(asymptotes ?? []).map((x) => mapX(x, xRange[0], xRange[1]))
+	);
 </script>
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor"
-	stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+	stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+	<!-- Axes sit behind the trace and are deliberately lighter, so a curve
+	     running along an axis (Abs, Deadband) stays readable. -->
 	{#if axes === 'baseline' || axes === 'cross'}
-		<line x1={AXIS_BOX.x0} y1={xAxisY} x2={AXIS_BOX.x1} y2={xAxisY} />
+		<g class="axis">
+			<line x1={AXIS_BOX.x0} y1={xAxisY} x2={AXIS_BOX.x1} y2={xAxisY} />
+			{#if axes === 'cross'}
+				<line x1={yAxisX} y1={AXIS_BOX.y0} x2={yAxisX} y2={AXIS_BOX.y1} />
+			{/if}
+		</g>
 	{/if}
-	{#if axes === 'cross'}
-		<line x1={yAxisX} y1={AXIS_BOX.y0} x2={yAxisX} y2={AXIS_BOX.y1} />
-	{/if}
+	{#each asymptoteX as ax}
+		<line class="asymptote" x1={ax} y1={PLOT_BOX.y0} x2={ax} y2={PLOT_BOX.y1} />
+	{/each}
 	{#if pathDashed}
-		<path d={pathDashed} stroke-dasharray="3 2.5" />
+		<path d={pathDashed} class="ghost" stroke-dasharray="3.5 3" />
 	{/if}
 	<path d={path} />
 	{#if markers}
@@ -58,16 +78,29 @@
 			<circle
 				cx={mapX(x, xRange[0], xRange[1])}
 				cy={mapY(v, yRange[0], yRange[1])}
-				r="3"
+				r="2.8"
 				fill="currentColor"
 				stroke="none"
 			/>
 		{/each}
 	{/if}
 	{#if decoration === 'arrow-up'}
-		<path d="M 88 40 L 88 24 M 84 28 L 88 24 L 92 28" />
+		<path d="M 86 44 L 86 22 M 82 26 L 86 22 L 90 26" />
 	{:else if decoration === 'arrow-down'}
-		<path d="M 88 24 L 88 40 M 84 36 L 88 40 L 92 36" />
+		<path d="M 86 22 L 86 44 M 82 40 L 86 44 L 90 40" />
+	{/if}
+	{#if badge}
+		<text
+			x={AXIS_BOX.x1}
+			y={AXIS_BOX.y0 + 2}
+			text-anchor="end"
+			dominant-baseline="hanging"
+			fill="currentColor"
+			stroke="none"
+			font-family="ui-monospace, 'JetBrains Mono', 'SF Mono', Menlo, monospace"
+			font-size="15"
+			font-weight="600">{badge}</text
+		>
 	{/if}
 </svg>
 
@@ -76,5 +109,20 @@
 		width: 100%;
 		height: 100%;
 		display: block;
+	}
+
+	.axis {
+		stroke-width: 0.9;
+		opacity: 0.42;
+	}
+
+	.asymptote {
+		stroke-width: 0.9;
+		opacity: 0.42;
+		stroke-dasharray: 3 3;
+	}
+
+	.ghost {
+		opacity: 0.5;
 	}
 </style>

--- a/src/lib/components/icons/blocks/IconPlot.svelte
+++ b/src/lib/components/icons/blocks/IconPlot.svelte
@@ -16,6 +16,8 @@
 		asymptotes?: number[];
 		/** Small superscript label in the top-right corner (e.g. base of a log). */
 		badge?: string;
+		/** Draw samples as stems from the zero line instead of a connected line. */
+		stems?: boolean;
 	}
 
 	let {
@@ -27,7 +29,8 @@
 		markers = false,
 		decoration,
 		asymptotes,
-		badge
+		badge,
+		stems = false
 	}: Props = $props();
 
 	const path = $derived(buildPath(samples, xRange[0], xRange[1], yRange[0], yRange[1]));
@@ -72,7 +75,15 @@
 	{#if pathDashed}
 		<path d={pathDashed} class="ghost" stroke-dasharray="3.5 3" />
 	{/if}
-	<path d={path} />
+	{#if stems}
+		{#each finiteSamples as [x, v]}
+			{@const sx = mapX(x, xRange[0], xRange[1])}
+			<line x1={sx} y1={xAxisY} x2={sx} y2={mapY(v, yRange[0], yRange[1])} />
+			<circle cx={sx} cy={mapY(v, yRange[0], yRange[1])} r="2.4" fill="currentColor" stroke="none" />
+		{/each}
+	{:else}
+		<path d={path} />
+	{/if}
 	{#if markers}
 		{#each finiteSamples as [x, v]}
 			<circle

--- a/src/lib/components/icons/blocks/IconPlot.svelte
+++ b/src/lib/components/icons/blocks/IconPlot.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { AXIS_BOX, PLOT_BOX, mapX, mapY, buildPath, type Sample } from './curves';
 
-	type AxesMode = 'none' | 'baseline' | 'cross';
+	/** 'baseline' = x only, 'yaxis' = y only, 'cross' = both. */
+	type AxesMode = 'none' | 'baseline' | 'yaxis' | 'cross';
 	type Decoration = 'arrow-up' | 'arrow-down';
 
 	interface Props {
@@ -59,12 +60,13 @@
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor"
 	stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-	<!-- Axes sit behind the trace and are deliberately lighter, so a curve
-	     running along an axis (Abs, Deadband) stays readable. -->
-	{#if axes === 'baseline' || axes === 'cross'}
+	<!-- Axes are drawn first so the trace stays on top where they cross. -->
+	{#if axes !== 'none'}
 		<g class="axis">
-			<line x1={AXIS_BOX.x0} y1={xAxisY} x2={AXIS_BOX.x1} y2={xAxisY} />
-			{#if axes === 'cross'}
+			{#if axes === 'baseline' || axes === 'cross'}
+				<line x1={AXIS_BOX.x0} y1={xAxisY} x2={AXIS_BOX.x1} y2={xAxisY} />
+			{/if}
+			{#if axes === 'yaxis' || axes === 'cross'}
 				<line x1={yAxisX} y1={AXIS_BOX.y0} x2={yAxisX} y2={AXIS_BOX.y1} />
 			{/if}
 		</g>
@@ -123,14 +125,15 @@
 		display: block;
 	}
 
+	/* Axes carry the same weight as the trace — at canvas scale anything
+	 * lighter disappears. */
 	.axis {
-		stroke-width: 0.9;
-		opacity: 0.42;
+		stroke-width: 1.6;
 	}
 
 	.asymptote {
-		stroke-width: 0.9;
-		opacity: 0.42;
+		stroke-width: 1.2;
+		opacity: 0.55;
 		stroke-dasharray: 3 3;
 	}
 

--- a/src/lib/components/icons/blocks/IconPoleZero.svelte
+++ b/src/lib/components/icons/blocks/IconPoleZero.svelte
@@ -56,7 +56,6 @@
 	}
 
 	.axis {
-		stroke-width: 0.9;
-		opacity: 0.42;
+		stroke-width: 1.6;
 	}
 </style>

--- a/src/lib/components/icons/blocks/IconPoleZero.svelte
+++ b/src/lib/components/icons/blocks/IconPoleZero.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	/**
+	 * Pole-zero map in the s-plane — poles as ×, zeros as ○.
+	 * Used for blocks parametrised by zeros/poles/gain, so they read
+	 * differently from the Bode-magnitude icons of coefficient-based blocks.
+	 */
+	import { AXIS_BOX, PLOT_BOX } from './curves';
+
+	interface Props {
+		/** Poles as [re, im] in a normalised [-1, 1] plane. */
+		poles?: Array<[number, number]>;
+		/** Zeros as [re, im]. */
+		zeros?: Array<[number, number]>;
+	}
+
+	let {
+		poles = [
+			[-0.55, 0.6],
+			[-0.55, -0.6]
+		],
+		zeros = [[0.45, 0]]
+	}: Props = $props();
+
+	const cx = (PLOT_BOX.x0 + PLOT_BOX.x1) / 2;
+	const cy = (PLOT_BOX.y0 + PLOT_BOX.y1) / 2;
+	const sx = PLOT_BOX.width / 2;
+	const sy = PLOT_BOX.height / 2;
+
+	const px = (re: number) => cx + re * sx;
+	const py = (im: number) => cy - im * sy;
+
+	const R = 3.4;
+</script>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor"
+	stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+	<g class="axis">
+		<line x1={AXIS_BOX.x0} y1={cy} x2={AXIS_BOX.x1} y2={cy} />
+		<line x1={cx} y1={AXIS_BOX.y0} x2={cx} y2={AXIS_BOX.y1} />
+	</g>
+	{#each poles as [re, im]}
+		{@const x = px(re)}
+		{@const y = py(im)}
+		<path d="M {x - R} {y - R} L {x + R} {y + R} M {x + R} {y - R} L {x - R} {y + R}" />
+	{/each}
+	{#each zeros as [re, im]}
+		<circle cx={px(re)} cy={py(im)} r={R} />
+	{/each}
+</svg>
+
+<style>
+	svg {
+		width: 100%;
+		height: 100%;
+		display: block;
+	}
+
+	.axis {
+		stroke-width: 0.9;
+		opacity: 0.42;
+	}
+</style>

--- a/src/lib/components/icons/blocks/IconScope.svelte
+++ b/src/lib/components/icons/blocks/IconScope.svelte
@@ -1,29 +1,43 @@
 <script lang="ts">
-	import { mapY, buildPath, type Sample } from './curves';
+	/**
+	 * Scope-style icon — a framed screen with a graticule and one or two traces.
+	 * With `bars` the samples are drawn as spectrum bars instead of a line.
+	 */
+	import { type Sample } from './curves';
 
 	interface Props {
 		samples: Sample[];
 		samples2?: Sample[];
 		yRange?: [number, number];
-		/** Number of vertical grid divisions */
+		/** Number of vertical grid divisions (0 disables). */
 		gridX?: number;
-		/** Number of horizontal grid divisions */
+		/** Number of horizontal grid divisions (0 disables). */
 		gridY?: number;
+		/** Render samples as bars rising from the baseline (spectrum). */
+		bars?: boolean;
 	}
 
-	let { samples, samples2, yRange = [-1.1, 1.1], gridX = 4, gridY = 3 }: Props = $props();
+	let {
+		samples,
+		samples2,
+		yRange = [-1.1, 1.1],
+		gridX = 4,
+		gridY = 3,
+		bars = false
+	}: Props = $props();
 
-	// Screen frame box (slightly larger than default plot box for scope feel)
-	const FRAME = { x0: 5, x1: 91, y0: 6, y1: 58 } as const;
+	/* Screen frame, centred in the 96×64 viewBox. */
+	const FRAME = { x0: 6, x1: 90, y0: 7, y1: 57 } as const;
 	const W = FRAME.x1 - FRAME.x0;
 	const H = FRAME.y1 - FRAME.y0;
 
-	// Local plot mapping inside the frame with small inset
-	const INSET = 7;
-	const plotX0 = FRAME.x0 + INSET;
-	const plotX1 = FRAME.x1 - INSET;
-	const plotY0 = FRAME.y0 + INSET;
-	const plotY1 = FRAME.y1 - INSET;
+	/* Signal area inset from the frame so the trace never touches the bezel. */
+	const INSET_X = 7;
+	const INSET_Y = 6;
+	const plotX0 = FRAME.x0 + INSET_X;
+	const plotX1 = FRAME.x1 - INSET_X;
+	const plotY0 = FRAME.y0 + INSET_Y;
+	const plotY1 = FRAME.y1 - INSET_Y;
 
 	function localMapX(t: number): number {
 		return plotX0 + t * (plotX1 - plotX0);
@@ -38,34 +52,41 @@
 			.map(([t, v], i) => `${i === 0 ? 'M' : 'L'} ${localMapX(t).toFixed(2)} ${localMapY(v).toFixed(2)}`)
 			.join(' ');
 	}
-	const path = $derived(pathFor(samples));
+	const path = $derived(bars ? '' : pathFor(samples));
 	const path2 = $derived(samples2 ? pathFor(samples2) : '');
 
 	const gridXLines = $derived(
-		Array.from({ length: gridX - 1 }, (_, i) => FRAME.x0 + ((i + 1) * W) / gridX)
+		gridX > 1 ? Array.from({ length: gridX - 1 }, (_, i) => FRAME.x0 + ((i + 1) * W) / gridX) : []
 	);
 	const gridYLines = $derived(
-		Array.from({ length: gridY - 1 }, (_, i) => FRAME.y0 + ((i + 1) * H) / gridY)
+		gridY > 1 ? Array.from({ length: gridY - 1 }, (_, i) => FRAME.y0 + ((i + 1) * H) / gridY) : []
 	);
+
+	const baseline = $derived(localMapY(yRange[0]));
 </script>
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor"
 	stroke-linecap="round" stroke-linejoin="round">
-	<!-- Outer screen frame -->
-	<rect x={FRAME.x0} y={FRAME.y0} width={W} height={H} rx="3" stroke-width="1.5" />
-	<!-- Grid -->
-	<g stroke-width="0.6" opacity="0.4">
+	<rect x={FRAME.x0} y={FRAME.y0} width={W} height={H} rx="4" stroke-width="1.6" />
+	<!-- Graticule: present but clearly behind the trace. -->
+	<g class="grid">
 		{#each gridXLines as gx}
-			<line x1={gx} y1={FRAME.y0 + 1} x2={gx} y2={FRAME.y1 - 1} />
+			<line x1={gx} y1={FRAME.y0 + 2} x2={gx} y2={FRAME.y1 - 2} />
 		{/each}
 		{#each gridYLines as gy}
-			<line x1={FRAME.x0 + 1} y1={gy} x2={FRAME.x1 - 1} y2={gy} />
+			<line x1={FRAME.x0 + 2} y1={gy} x2={FRAME.x1 - 2} y2={gy} />
 		{/each}
 	</g>
-	<!-- Signal traces -->
-	<path d={path} stroke-width="1.5" />
-	{#if path2}
-		<path d={path2} stroke-width="1.5" stroke-dasharray="4 4" stroke-dashoffset="2" />
+	{#if bars}
+		{#each samples as [t, v]}
+			<line class="bar" x1={localMapX(t)} y1={baseline} x2={localMapX(t)} y2={localMapY(v)} />
+		{/each}
+		<line class="baseline" x1={plotX0} y1={baseline} x2={plotX1} y2={baseline} />
+	{:else}
+		<path d={path} stroke-width="1.6" />
+		{#if path2}
+			<path d={path2} stroke-width="1.6" stroke-dasharray="4 4" stroke-dashoffset="2" />
+		{/if}
 	{/if}
 </svg>
 
@@ -74,5 +95,20 @@
 		width: 100%;
 		height: 100%;
 		display: block;
+	}
+
+	.grid {
+		stroke-width: 0.8;
+		opacity: 0.35;
+	}
+
+	.bar {
+		stroke-width: 3.2;
+		stroke-linecap: butt;
+	}
+
+	.baseline {
+		stroke-width: 1.2;
+		opacity: 0.5;
 	}
 </style>

--- a/src/lib/components/icons/blocks/curves.ts
+++ b/src/lib/components/icons/blocks/curves.ts
@@ -7,29 +7,33 @@
 
 export type Sample = [number, number];
 
-/** Box used to draw axes — the visible "frame" of the plot. */
-export const AXIS_BOX = {
-	x0: 12,
-	x1: 88,
-	y0: 8,
-	y1: 56
-} as const;
-
-/** Inset between axes box and the actual signal area, gives axes headroom. */
-const SIGNAL_INSET = 8;
-
-/** Box used to map sample values into pixels — strictly inside AXIS_BOX. */
+/**
+ * Geometry. The signal area (PLOT_BOX) is centred in the 96×64 viewBox; the
+ * axes overshoot it by AXIS_OVERSHOOT on every side, so an icon stays visually
+ * balanced no matter which axes it draws.
+ */
 export const PLOT_BOX = {
-	x0: AXIS_BOX.x0 + SIGNAL_INSET / 2,
-	x1: AXIS_BOX.x1 - SIGNAL_INSET,
-	y0: AXIS_BOX.y0 + SIGNAL_INSET,
-	y1: AXIS_BOX.y1 - SIGNAL_INSET / 2,
+	x0: 14,
+	x1: 82,
+	y0: 14,
+	y1: 50,
 	get width() {
 		return this.x1 - this.x0;
 	},
 	get height() {
 		return this.y1 - this.y0;
 	}
+} as const;
+
+/** How far the axes extend past the signal area. */
+const AXIS_OVERSHOOT = 4;
+
+/** Box used to draw axes — the visible "frame" of the plot. */
+export const AXIS_BOX = {
+	x0: PLOT_BOX.x0 - AXIS_OVERSHOOT,
+	x1: PLOT_BOX.x1 + AXIS_OVERSHOOT,
+	y0: PLOT_BOX.y0 - AXIS_OVERSHOOT,
+	y1: PLOT_BOX.y1 + AXIS_OVERSHOOT
 } as const;
 
 export function mapX(x: number, xMin = 0, xMax = 1): number {

--- a/src/lib/components/icons/blocks/curves.ts
+++ b/src/lib/components/icons/blocks/curves.ts
@@ -696,13 +696,52 @@ export function randomStemSamples(n = 11, seed = 7): Sample[] {
 	return out;
 }
 
-/** Reconstructed analog ramp for the DAC icon — the smooth counterpart to the
- *  quantizer staircase. */
+/** Reconstructed analog ramp — the smooth counterpart to a quantizer staircase. */
 export function rampBipolarSamples(): Sample[] {
 	return [
 		[-1, -1],
 		[1, 1]
 	];
+}
+
+/* --- Converters (ADC / DAC) --------------------------------------------
+ * Both icons show the same analog signal as a dashed ghost. The ADC adds the
+ * sample instants taken from it, the DAC the held signal reconstructed from
+ * them — so the pair reads as "sampling" versus "holding".
+ */
+
+const CONVERTER_AMP = 0.85;
+const CONVERTER_CYCLES = 1.15;
+
+function converterSignal(t: number): number {
+	return CONVERTER_AMP * Math.sin(2 * Math.PI * CONVERTER_CYCLES * t);
+}
+
+/** The continuous signal both converter icons reference. */
+export function converterAnalogSamples(n = 90): Sample[] {
+	return Array.from({ length: n }, (_, i) => {
+		const t = i / (n - 1);
+		return [t, converterSignal(t)] as Sample;
+	});
+}
+
+/** Sample instants taken from that signal — drawn as stems by the ADC icon. */
+export function converterSampleSamples(n = 7): Sample[] {
+	return Array.from({ length: n }, (_, i) => {
+		const t = (i + 0.5) / n;
+		return [t, converterSignal(t)] as Sample;
+	});
+}
+
+/** Zero-order-hold reconstruction of those samples — the DAC output. */
+export function converterHeldSamples(n = 7): Sample[] {
+	const out: Sample[] = [];
+	for (let i = 0; i < n; i++) {
+		const v = converterSignal((i + 0.5) / n);
+		out.push([i / n, v]);
+		out.push([(i + 1) / n, v]);
+	}
+	return out;
 }
 
 /* --- Scope-style display signals --------------------------------------- */

--- a/src/lib/components/icons/blocks/curves.ts
+++ b/src/lib/components/icons/blocks/curves.ts
@@ -746,24 +746,24 @@ export function dampedOscillation(zeta = 0.06, cycles = 2.5, t0 = 0.05, n = 140)
 	return out;
 }
 
+/** Spectrum line heights — one entry per bin, rendered as bars by IconScope.
+ *  Shaped like a real spectrum: a dominant fundamental with decaying harmonics
+ *  sitting on a low noise floor. */
 export function spectrumBars(): Sample[] {
-	const peaks = [
-		[0.08, 0.15],
-		[0.18, 0.55],
-		[0.28, 0.85],
-		[0.38, 0.65],
-		[0.5, 0.4],
-		[0.62, 0.7],
-		[0.74, 0.3],
-		[0.86, 0.5],
-		[0.94, 0.18]
-	] as Array<[number, number]>;
-	const out: Sample[] = [[0, 0]];
-	for (const [t, h] of peaks) {
-		out.push([t, 0]);
-		out.push([t, h]);
-		out.push([t, 0]);
-	}
-	out.push([1, 0]);
-	return out;
+	return [
+		[0.1, 0.28],
+		[0.22, 1.0],
+		[0.34, 0.2],
+		[0.46, 0.62],
+		[0.58, 0.16],
+		[0.7, 0.4],
+		[0.82, 0.14],
+		[0.94, 0.24]
+	];
+}
+
+/** PID step response hitting an actuator limit — the flat top is the
+ *  saturation the anti-windup logic deals with. */
+export function antiWindupStepSamples(limit = 0.82, t0 = 0.12, n = 100): Sample[] {
+	return pt2StepSamples(0.4, 18, t0, n).map(([t, v]) => [t, Math.min(v, limit)] as Sample);
 }

--- a/src/lib/components/icons/blocks/curves.ts
+++ b/src/lib/components/icons/blocks/curves.ts
@@ -80,32 +80,29 @@ export function sineSamples(cycles = 1.5, n = 64): Sample[] {
 	return out;
 }
 
-export function squareSamples(cycles = 1.5): Sample[] {
+/** Square wave over whole periods, so the trace closes cleanly at both edges. */
+export function squareSamples(cycles = 2): Sample[] {
 	const out: Sample[] = [];
 	const period = 1 / cycles;
-	let t = 0;
-	out.push([0, 1]);
-	while (t < 1) {
-		const tHigh = Math.min(1, t + period / 2);
-		out.push([tHigh, 1]);
-		out.push([tHigh, -1]);
-		const tLow = Math.min(1, t + period);
-		out.push([tLow, -1]);
-		if (tLow < 1) {
-			out.push([tLow, 1]);
-		}
-		t += period;
+	for (let c = 0; c < cycles; c++) {
+		const t0 = c * period;
+		out.push([t0, 1]);
+		out.push([t0 + period / 2, 1]);
+		out.push([t0 + period / 2, -1]);
+		out.push([t0 + period, -1]);
+		if (c < cycles - 1) out.push([t0 + period, 1]);
 	}
 	return out;
 }
 
-export function triangleSamples(cycles = 1.5, n = 80): Sample[] {
+/** Triangle wave over whole periods, starting and ending at the zero crossing. */
+export function triangleSamples(cycles = 2, n = 81): Sample[] {
 	const out: Sample[] = [];
 	for (let i = 0; i < n; i++) {
 		const t = i / (n - 1);
-		const phase = (t * cycles * 2) % 2;
-		const v = phase < 1 ? phase : 2 - phase;
-		out.push([t, v * 2 - 1]);
+		const phase = (t * cycles * 4) % 4;
+		const v = phase < 1 ? phase : phase < 3 ? 2 - phase : phase - 4;
+		out.push([t, v]);
 	}
 	return out;
 }
@@ -423,6 +420,17 @@ export function cosFunctionSamples(n = 80): Sample[] {
 	return out;
 }
 
+/** atan2 characteristic — the arctan S-curve saturating towards ±π/2,
+ *  normalised so ±π/2 maps to ±1. */
+export function atan2Samples(gain = 4, n = 80): Sample[] {
+	const out: Sample[] = [];
+	for (let i = 0; i < n; i++) {
+		const x = -1 + (2 * i) / (n - 1);
+		out.push([x, Math.atan(x * gain) / (Math.PI / 2)]);
+	}
+	return out;
+}
+
 export function powSamples(exp = 2, n = 60): Sample[] {
 	const out: Sample[] = [];
 	for (let i = 0; i < n; i++) {
@@ -475,18 +483,16 @@ export function pidStepSamples(t0 = 0.12, n = 100): Sample[] {
 	return pt2StepSamples(0.4, 18, t0, n);
 }
 
-/** Modulo / sawtooth: y = x mod period over x ∈ [0, 1] */
-export function modSamples(period = 0.3): Sample[] {
+/** Modulo / sawtooth: y = x mod period, over a whole number of periods so no
+ *  tooth is cut off at the right edge. */
+export function modSamples(teeth = 3): Sample[] {
 	const out: Sample[] = [];
-	let t = 0;
-	while (t < 1) {
-		out.push([t, 0]);
-		const tEnd = Math.min(1, t + period);
-		out.push([tEnd, (tEnd - t) / period]);
-		if (tEnd < 1) {
-			out.push([tEnd, 0]);
-		}
-		t = tEnd;
+	const period = 1 / teeth;
+	for (let i = 0; i < teeth; i++) {
+		const t0 = i * period;
+		out.push([t0, 0]);
+		out.push([t0 + period, 1]);
+		if (i < teeth - 1) out.push([t0 + period, 0]);
 	}
 	return out;
 }
@@ -662,12 +668,40 @@ export function firstOrderHoldSamples(n = 6): Sample[] {
 	return out;
 }
 
-export function backlashSamples(): Sample[] {
+/** Backlash — closed hysteresis loop: the rising branch, then the falling one
+ *  traced back, so the dead zone between them is visible as an open shape. */
+export function backlashSamples(width = 0.42, gain = 0.8): Sample[] {
 	return [
-		[-1, -0.7],
-		[-0.3, -0.7],
-		[0.3, 0.7],
-		[1, 0.7]
+		// rising branch
+		[-1, -gain],
+		[-1 + 2 * width, -gain],
+		[1, gain],
+		// falling branch, traced back to the start
+		[1 - 2 * width, gain],
+		[-1, -gain]
+	];
+}
+
+/** Discrete random draws — one value per sample instant, rendered as stems. */
+export function randomStemSamples(n = 11, seed = 7): Sample[] {
+	let s = seed;
+	const rand = () => {
+		s = (s * 9301 + 49297) % 233280;
+		return s / 233280;
+	};
+	const out: Sample[] = [];
+	for (let i = 0; i < n; i++) {
+		out.push([(i + 0.5) / n, rand() * 1.8 - 0.9]);
+	}
+	return out;
+}
+
+/** Reconstructed analog ramp for the DAC icon — the smooth counterpart to the
+ *  quantizer staircase. */
+export function rampBipolarSamples(): Sample[] {
+	return [
+		[-1, -1],
+		[1, 1]
 	];
 }
 

--- a/src/lib/components/icons/blocks/curves.ts
+++ b/src/lib/components/icons/blocks/curves.ts
@@ -707,16 +707,13 @@ export function rampBipolarSamples(): Sample[] {
 
 /* --- Scope-style display signals --------------------------------------- */
 
-/** Superposition of three sin/cos components — visually rich oscilloscope trace */
-export function superposedSignal(n = 220): Sample[] {
+/** Ringing step response — the Scope trace. A decaying oscillation reads as a
+ *  signal at any size and spans the screen without the noise of a superposition. */
+export function scopeTrace(decay = 1.45, cycles = 3, n = 200): Sample[] {
 	const out: Sample[] = [];
 	for (let i = 0; i < n; i++) {
 		const t = i / (n - 1);
-		const v =
-			0.55 * Math.sin(2 * Math.PI * 1.2 * t) +
-			0.4 * Math.sin(2 * Math.PI * 5.2 * t + 0.4) +
-			0.08 * Math.cos(2 * Math.PI * 11 * t);
-		out.push([t, v]);
+		out.push([t, Math.exp(-decay * t) * Math.sin(2 * Math.PI * cycles * t)]);
 	}
 	return out;
 }

--- a/src/lib/components/icons/blocks/registry.ts
+++ b/src/lib/components/icons/blocks/registry.ts
@@ -179,7 +179,7 @@ export const iconRegistry: Record<string, IconDef> = {
 	Interface: { kind: 'svg', name: 'Interface' },
 	Scope: {
 		kind: 'scope',
-		samples: () => C.superposedSignal(),
+		samples: () => C.scopeTrace(),
 		yRange: [-1.15, 1.15],
 		gridX: 4,
 		gridY: 2

--- a/src/lib/components/icons/blocks/registry.ts
+++ b/src/lib/components/icons/blocks/registry.ts
@@ -116,20 +116,19 @@ export const iconRegistry: Record<string, IconDef> = {
 	Atan2: { kind: 'plot', samples: () => C.atan2Samples(), xRange: X_BIPOLAR, yRange: [-1.25, 1.25] },
 
 	/* --- Quantisation / counters ---
-	 * ADC and DAC are mirror images: the ghost trace is the input, the solid
-	 * one the output — continuous in, stepped out for ADC and vice versa. */
+	 * ADC and DAC share the same dashed analog signal: the ADC adds the sample
+	 * instants taken from it, the DAC the held signal rebuilt from them. */
 	ADC: {
 		kind: 'plot',
-		samples: () => C.quantizerSamples(),
-		samplesDashed: () => C.rampBipolarSamples(),
-		xRange: X_BIPOLAR,
-		yRange: Y_BIPOLAR
+		samples: () => C.converterSampleSamples(),
+		samplesDashed: () => C.converterAnalogSamples(),
+		yRange: Y_BIPOLAR,
+		stems: true
 	},
 	DAC: {
 		kind: 'plot',
-		samples: () => C.rampBipolarSamples(),
-		samplesDashed: () => C.quantizerSamples(),
-		xRange: X_BIPOLAR,
+		samples: () => C.converterHeldSamples(),
+		samplesDashed: () => C.converterAnalogSamples(),
 		yRange: Y_BIPOLAR
 	},
 	Counter: { kind: 'plot', samples: () => C.counterUpSamples() },
@@ -153,7 +152,9 @@ export const iconRegistry: Record<string, IconDef> = {
 	Polynomial: { kind: 'math', latex: '\\sum c_k\\,u^{k}' },
 
 	/* --- Discrete-time blocks --- */
-	FirstOrderHold: { kind: 'plot', samples: () => C.firstOrderHoldSamples() },
+	// Markers make it read as interpolation between sample instants — the same
+	// instants SampleHold shows as a staircase.
+	FirstOrderHold: { kind: 'plot', samples: () => C.firstOrderHoldSamples(), markers: true },
 	DiscreteIntegrator: { kind: 'math', latex: '\\dfrac{T}{z-1}' },
 	DiscreteDerivative: { kind: 'math', latex: '\\dfrac{z-1}{T\\,z}' },
 	DiscreteStateSpace: { kind: 'math', latex: 'x_{k+1} = Ax_k{+}Bu_k' },

--- a/src/lib/components/icons/blocks/registry.ts
+++ b/src/lib/components/icons/blocks/registry.ts
@@ -4,9 +4,14 @@
  * Renderer types:
  *   - 'plot':  programmatic curve with optional axes (Sources, responses, nonlinearities)
  *   - 'scope': framed plot with grid (Scope/Spectrum)
+ *   - 'pz':    pole-zero map in the s-plane (zero/pole/gain blocks)
  *   - 'math':  KaTeX-rendered LaTeX (transfer functions, ODEs, operators)
  *   - 'glyph': monospace text label (PID, ADC, DAC, …)
  *   - 'svg':   raw SVG file from ./svg/<BlockClass>.svg (geometric symbols)
+ *
+ * Every icon shares the geometry defined in ./curves (96×64 viewBox, centred
+ * PLOT_BOX, axes overshooting it by a fixed margin), so icons stay comparable
+ * in weight and size when placed side by side on the canvas.
  */
 
 import type { Sample } from './curves';
@@ -15,7 +20,8 @@ import * as C from './curves';
 type AxesMode = 'none' | 'baseline' | 'cross';
 
 export type IconDef =
-	| { kind: 'plot'; samples: () => Sample[]; samplesDashed?: () => Sample[]; xRange?: [number, number]; yRange?: [number, number]; axes?: AxesMode; markers?: boolean; decoration?: 'arrow-up' | 'arrow-down' }
+	| { kind: 'plot'; samples: () => Sample[]; samplesDashed?: () => Sample[]; xRange?: [number, number]; yRange?: [number, number]; axes?: AxesMode; markers?: boolean; decoration?: 'arrow-up' | 'arrow-down'; asymptotes?: number[]; badge?: string; stems?: boolean }
+	| { kind: 'pz'; poles?: Array<[number, number]>; zeros?: Array<[number, number]> }
 	| { kind: 'scope'; samples: () => Sample[]; samples2?: () => Sample[]; yRange?: [number, number]; gridX?: number; gridY?: number }
 	| { kind: 'surface'; fn?: (u: number, v: number) => number; rows?: number; cols?: number }
 	| { kind: 'math'; latex: string }
@@ -42,7 +48,8 @@ export const iconRegistry: Record<string, IconDef> = {
 	ChirpPhaseNoiseSource: { kind: 'plot', samples: () => C.chirpSamples(), yRange: Y_BIPOLAR },
 	WhiteNoise: { kind: 'plot', samples: () => C.whiteNoiseSamples(), yRange: Y_BIPOLAR },
 	PinkNoise: { kind: 'plot', samples: () => C.pinkNoiseSamples(), yRange: Y_BIPOLAR },
-	RandomNumberGenerator: { kind: 'plot', samples: () => C.whiteNoiseSamples(16, 13), yRange: Y_BIPOLAR },
+	// Discrete draws, not a continuous trace — keeps it apart from the noise sources.
+	RandomNumberGenerator: { kind: 'plot', samples: () => C.randomStemSamples(), yRange: Y_BIPOLAR, stems: true },
 	ClockSource: { kind: 'plot', samples: () => C.clockSamples() },
 	Source: { kind: 'math', latex: 'f(t)' },
 
@@ -68,13 +75,16 @@ export const iconRegistry: Record<string, IconDef> = {
 	ButterworthBandstopFilter: { kind: 'plot', samples: () => C.butterBandstopBode() },
 	FIR: { kind: 'plot', samples: () => C.firBode() },
 	TransferFunctionNumDen: { kind: 'plot', samples: () => C.genericBode(0.35), yRange: GENERIC_BODE_Y },
-	TransferFunctionZPG: { kind: 'plot', samples: () => C.genericBode(0.35), yRange: GENERIC_BODE_Y },
+	// Parametrised by zeros/poles/gain — shown as the pole-zero map rather than
+	// the same Bode magnitude as the coefficient form.
+	TransferFunctionZPG: { kind: 'pz' },
 
 	/* --- Static nonlinearities (input-output, x in real domain) --- */
 	Tanh: { kind: 'plot', samples: () => C.tanhSamples(), xRange: X_BIPOLAR, yRange: Y_BIPOLAR },
 	Exp: { kind: 'plot', samples: () => C.expSamples() },
 	Log: { kind: 'plot', samples: () => C.logSamples() },
-	Log10: { kind: 'plot', samples: () => C.logSamples() },
+	// Same curve shape as Log — the base is what distinguishes the two.
+	Log10: { kind: 'plot', samples: () => C.logSamples(), badge: '10' },
 	Sqrt: { kind: 'plot', samples: () => C.sqrtSamples() },
 	Abs: { kind: 'plot', samples: () => C.absSamples(), xRange: X_BIPOLAR },
 	Clip: { kind: 'plot', samples: () => C.clipSamples(), xRange: X_BIPOLAR, yRange: Y_TIGHT },
@@ -87,35 +97,58 @@ export const iconRegistry: Record<string, IconDef> = {
 	/* --- Trig / power --- */
 	Sin: { kind: 'plot', samples: () => C.sinFunctionSamples(), xRange: TRIG_X_RANGE, yRange: Y_BIPOLAR },
 	Cos: { kind: 'plot', samples: () => C.cosFunctionSamples(), xRange: TRIG_X_RANGE, yRange: Y_BIPOLAR },
-	Tan: { kind: 'plot', samples: () => C.tanFunctionSamples(), xRange: TRIG_X_RANGE, yRange: [-1.6, 1.6] },
+	Tan: {
+		kind: 'plot',
+		samples: () => C.tanFunctionSamples(),
+		xRange: TRIG_X_RANGE,
+		yRange: [-1.6, 1.6],
+		asymptotes: [-Math.PI / 2, Math.PI / 2]
+	},
 	Pow: { kind: 'plot', samples: () => C.powSamples(2), xRange: X_BIPOLAR },
 	Mod: { kind: 'plot', samples: () => C.modSamples() },
+	Atan2: { kind: 'plot', samples: () => C.atan2Samples(), xRange: X_BIPOLAR, yRange: [-1.25, 1.25] },
 
-	/* --- Quantisation / counters --- */
-	ADC: { kind: 'plot', samples: () => C.quantizerSamples(), xRange: X_BIPOLAR, yRange: Y_BIPOLAR },
-	DAC: { kind: 'plot', samples: () => C.quantizerSamples(), xRange: X_BIPOLAR, yRange: Y_BIPOLAR },
+	/* --- Quantisation / counters ---
+	 * ADC and DAC are mirror images: the ghost trace is the input, the solid
+	 * one the output — continuous in, stepped out for ADC and vice versa. */
+	ADC: {
+		kind: 'plot',
+		samples: () => C.quantizerSamples(),
+		samplesDashed: () => C.rampBipolarSamples(),
+		xRange: X_BIPOLAR,
+		yRange: Y_BIPOLAR
+	},
+	DAC: {
+		kind: 'plot',
+		samples: () => C.rampBipolarSamples(),
+		samplesDashed: () => C.quantizerSamples(),
+		xRange: X_BIPOLAR,
+		yRange: Y_BIPOLAR
+	},
 	Counter: { kind: 'plot', samples: () => C.counterUpSamples() },
 	CounterUp: { kind: 'plot', samples: () => C.counterUpSamples(), decoration: 'arrow-up' },
-	CounterDown: { kind: 'plot', samples: () => C.counterUpSamples(), decoration: 'arrow-down' },
+	CounterDown: { kind: 'plot', samples: () => C.counterDownSamples(), decoration: 'arrow-down' },
 
 	/* --- Lookup tables --- */
 	LUT1D: { kind: 'plot', samples: () => C.lut1dSamples(), xRange: X_BIPOLAR, yRange: Y_BIPOLAR, markers: true },
 	LUT: { kind: 'surface', fn: (u, v) => -0.18 * (u + v) + 0.3 * u * v },
 
-	/* --- Math (KaTeX) --- */
+	/* --- Math (KaTeX) ---
+	 * Kept to a single short line wherever possible: at canvas scale a block is
+	 * 80×40 px, so a two-line formula degrades into unreadable texture. */
 	ODE: { kind: 'math', latex: '\\dot{x} = f(x, u, t)' },
-	StateSpace: { kind: 'math', latex: '\\begin{aligned}\\dot{x} &= Ax{+}Bu\\\\ y &= Cx{+}Du\\end{aligned}' },
-	DynamicalSystem: { kind: 'math', latex: '\\begin{aligned}\\dot{x} &= f(x, u, t)\\\\ y &= g(x, u, t)\\end{aligned}' },
+	StateSpace: { kind: 'math', latex: '\\dot{x} = Ax{+}Bu' },
+	DynamicalSystem: { kind: 'math', latex: '\\dot{x} = f(x, u, t)' },
 	DynamicalFunction: { kind: 'math', latex: 'f(u, t)' },
 	Function: { kind: 'math', latex: 'f(u)' },
-	Polynomial: { kind: 'math', latex: 'y = \\sum_{k=0}^{n} c_k\\,u^{n-k}' },
+	Polynomial: { kind: 'math', latex: '\\sum c_k\\,u^{k}' },
 
 	/* --- Discrete-time blocks --- */
 	FirstOrderHold: { kind: 'plot', samples: () => C.firstOrderHoldSamples() },
 	DiscreteIntegrator: { kind: 'math', latex: '\\dfrac{T}{z-1}' },
 	DiscreteDerivative: { kind: 'math', latex: '\\dfrac{z-1}{T\\,z}' },
-	DiscreteStateSpace: { kind: 'math', latex: '\\begin{aligned}x[k{+}1] &= Ax[k]{+}Bu[k]\\\\ y[k] &= Cx[k]{+}Du[k]\\end{aligned}' },
-	DiscreteTransferFunction: { kind: 'math', latex: 'H(z) = \\dfrac{B(z)}{A(z)}' },
+	DiscreteStateSpace: { kind: 'math', latex: 'x_{k+1} = Ax_k{+}Bu_k' },
+	DiscreteTransferFunction: { kind: 'math', latex: '\\dfrac{B(z)}{A(z)}' },
 	TappedDelay: { kind: 'svg', name: 'TappedDelay' },
 
 	/* --- Geometric SVGs (kept as files) --- */
@@ -123,11 +156,18 @@ export const iconRegistry: Record<string, IconDef> = {
 	Multiplier: { kind: 'svg', name: 'Multiplier' },
 	Amplifier: { kind: 'svg', name: 'Amplifier' },
 	Rescale: { kind: 'svg', name: 'Amplifier' },
+	Divider: { kind: 'svg', name: 'Divider' },
 	LogicAnd: { kind: 'svg', name: 'LogicAnd' },
 	LogicOr: { kind: 'svg', name: 'LogicOr' },
 	LogicNot: { kind: 'svg', name: 'LogicNot' },
+	Equal: { kind: 'svg', name: 'Equal' },
+	GreaterThan: { kind: 'svg', name: 'GreaterThan' },
+	LessThan: { kind: 'svg', name: 'LessThan' },
+	Alias: { kind: 'svg', name: 'Alias' },
+	Wrapper: { kind: 'svg', name: 'Wrapper' },
 	Switch: { kind: 'svg', name: 'Switch' },
 	Subsystem: { kind: 'svg', name: 'Subsystem' },
+	Interface: { kind: 'svg', name: 'Interface' },
 	Scope: {
 		kind: 'scope',
 		samples: () => C.superposedSignal(),

--- a/src/lib/components/icons/blocks/registry.ts
+++ b/src/lib/components/icons/blocks/registry.ts
@@ -94,7 +94,9 @@ export const iconRegistry: Record<string, IconDef> = {
 	// The dead zone lies exactly on the x-axis — drawing it would hide the very
 	// feature the icon is about.
 	Deadband: { kind: 'plot', samples: () => C.deadbandSamples(), xRange: X_BIPOLAR, yRange: Y_TIGHT, axes: 'yaxis' },
-	Relay: { kind: 'plot', samples: () => C.relaySamples(), xRange: X_BIPOLAR, yRange: Y_BIPOLAR },
+	// Axis-parallel hysteresis loop — with axes drawn through it the icon reads
+	// as a hash mark, so the loop stands on its own.
+	Relay: { kind: 'plot', samples: () => C.relaySamples(0.45), xRange: X_BIPOLAR, yRange: Y_BIPOLAR, axes: 'none' },
 	RateLimiter: { kind: 'plot', samples: () => C.rateLimiterSamples() },
 	SampleHold: { kind: 'plot', samples: () => C.sampleHoldSamples() },
 	Backlash: { kind: 'plot', samples: () => C.backlashSamples(), xRange: X_BIPOLAR, yRange: Y_BIPOLAR },

--- a/src/lib/components/icons/blocks/registry.ts
+++ b/src/lib/components/icons/blocks/registry.ts
@@ -17,12 +17,12 @@
 import type { Sample } from './curves';
 import * as C from './curves';
 
-type AxesMode = 'none' | 'baseline' | 'cross';
+type AxesMode = 'none' | 'baseline' | 'yaxis' | 'cross';
 
 export type IconDef =
 	| { kind: 'plot'; samples: () => Sample[]; samplesDashed?: () => Sample[]; xRange?: [number, number]; yRange?: [number, number]; axes?: AxesMode; markers?: boolean; decoration?: 'arrow-up' | 'arrow-down'; asymptotes?: number[]; badge?: string; stems?: boolean }
 	| { kind: 'pz'; poles?: Array<[number, number]>; zeros?: Array<[number, number]> }
-	| { kind: 'scope'; samples: () => Sample[]; samples2?: () => Sample[]; yRange?: [number, number]; gridX?: number; gridY?: number }
+	| { kind: 'scope'; samples: () => Sample[]; samples2?: () => Sample[]; yRange?: [number, number]; gridX?: number; gridY?: number; bars?: boolean }
 	| { kind: 'surface'; fn?: (u: number, v: number) => number; rows?: number; cols?: number }
 	| { kind: 'math'; latex: string }
 	| { kind: 'glyph'; text: string; size?: number }
@@ -66,7 +66,8 @@ export const iconRegistry: Record<string, IconDef> = {
 		yRange: Y_BIPOLAR
 	},
 	PID: { kind: 'plot', samples: () => C.pidStepSamples(), yRange: PT2_RANGE },
-	AntiWindupPID: { kind: 'plot', samples: () => C.pt1StepSamples(0.12, 0.12) },
+	// Saturating response — visibly different from the plain PID overshoot.
+	AntiWindupPID: { kind: 'plot', samples: () => C.antiWindupStepSamples(), yRange: PT2_RANGE },
 
 	/* --- Bode magnitude (Filters / generic transfer functions) --- */
 	ButterworthLowpassFilter: { kind: 'plot', samples: () => C.butterLowpassBode() },
@@ -86,9 +87,13 @@ export const iconRegistry: Record<string, IconDef> = {
 	// Same curve shape as Log — the base is what distinguishes the two.
 	Log10: { kind: 'plot', samples: () => C.logSamples(), badge: '10' },
 	Sqrt: { kind: 'plot', samples: () => C.sqrtSamples() },
-	Abs: { kind: 'plot', samples: () => C.absSamples(), xRange: X_BIPOLAR },
+	// The V sits on the zero line, so drawing the y-axis through its vertex too
+	// would turn the icon into a four-armed fan — baseline only.
+	Abs: { kind: 'plot', samples: () => C.absSamples(), xRange: X_BIPOLAR, axes: 'baseline' },
 	Clip: { kind: 'plot', samples: () => C.clipSamples(), xRange: X_BIPOLAR, yRange: Y_TIGHT },
-	Deadband: { kind: 'plot', samples: () => C.deadbandSamples(), xRange: X_BIPOLAR, yRange: Y_TIGHT },
+	// The dead zone lies exactly on the x-axis — drawing it would hide the very
+	// feature the icon is about.
+	Deadband: { kind: 'plot', samples: () => C.deadbandSamples(), xRange: X_BIPOLAR, yRange: Y_TIGHT, axes: 'yaxis' },
 	Relay: { kind: 'plot', samples: () => C.relaySamples(), xRange: X_BIPOLAR, yRange: Y_BIPOLAR },
 	RateLimiter: { kind: 'plot', samples: () => C.rateLimiterSamples() },
 	SampleHold: { kind: 'plot', samples: () => C.sampleHoldSamples() },
@@ -138,7 +143,9 @@ export const iconRegistry: Record<string, IconDef> = {
 	 * 80×40 px, so a two-line formula degrades into unreadable texture. */
 	ODE: { kind: 'math', latex: '\\dot{x} = f(x, u, t)' },
 	StateSpace: { kind: 'math', latex: '\\dot{x} = Ax{+}Bu' },
-	DynamicalSystem: { kind: 'math', latex: '\\dot{x} = f(x, u, t)' },
+	// Keeps the output equation ODE does not have — abbreviated so two lines
+	// still scale up rather than turning to texture.
+	DynamicalSystem: { kind: 'math', latex: '\\begin{aligned}\\dot{x} &= f\\\\ y &= g\\end{aligned}' },
 	DynamicalFunction: { kind: 'math', latex: 'f(u, t)' },
 	Function: { kind: 'math', latex: 'f(u)' },
 	Polynomial: { kind: 'math', latex: '\\sum c_k\\,u^{k}' },
@@ -171,11 +178,18 @@ export const iconRegistry: Record<string, IconDef> = {
 	Scope: {
 		kind: 'scope',
 		samples: () => C.superposedSignal(),
-		yRange: [-1.05, 1.05],
-		gridX: 0,
-		gridY: 0
+		yRange: [-1.15, 1.15],
+		gridX: 4,
+		gridY: 2
 	},
-	Spectrum: { kind: 'scope', samples: () => C.spectrumBars(), yRange: [0, 1], gridX: 0, gridY: 0 }
+	Spectrum: {
+		kind: 'scope',
+		samples: () => C.spectrumBars(),
+		yRange: [0, 1.12],
+		gridX: 0,
+		gridY: 2,
+		bars: true
+	}
 };
 
 export function getIconDef(blockClass: string | undefined): IconDef | undefined {

--- a/src/lib/components/icons/blocks/svg/Adder.svg
+++ b/src/lib/components/icons/blocks/svg/Adder.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M 60 18 L 60 14 L 36 14 L 44 32 L 36 50 L 60 50 L 60 46"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M 62 19 L 62 14 L 34 14 L 44 32 L 34 50 L 62 50 L 62 45"/>
 </svg>

--- a/src/lib/components/icons/blocks/svg/Alias.svg
+++ b/src/lib/components/icons/blocks/svg/Alias.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="18" y1="32" x2="34" y2="32"/>
+  <line x1="62" y1="32" x2="78" y2="32"/>
+  <path d="M 34 22 H 56 L 62 32 L 56 42 H 34 Z"/>
+  <circle cx="40" cy="32" r="2" fill="currentColor" stroke="none"/>
+</svg>

--- a/src/lib/components/icons/blocks/svg/Amplifier.svg
+++ b/src/lib/components/icons/blocks/svg/Amplifier.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <polygon points="26,10 26,54 78,32"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <polygon points="27,14 27,50 69,32"/>
 </svg>

--- a/src/lib/components/icons/blocks/svg/Divider.svg
+++ b/src/lib/components/icons/blocks/svg/Divider.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="32" y1="32" x2="64" y2="32"/>
+  <circle cx="48" cy="20" r="3" fill="currentColor" stroke="none"/>
+  <circle cx="48" cy="44" r="3" fill="currentColor" stroke="none"/>
+</svg>

--- a/src/lib/components/icons/blocks/svg/Equal.svg
+++ b/src/lib/components/icons/blocks/svg/Equal.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="32" y1="25" x2="64" y2="25"/>
+  <line x1="32" y1="39" x2="64" y2="39"/>
+</svg>

--- a/src/lib/components/icons/blocks/svg/GreaterThan.svg
+++ b/src/lib/components/icons/blocks/svg/GreaterThan.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M 36 17 L 62 32 L 36 47"/>
+</svg>

--- a/src/lib/components/icons/blocks/svg/Interface.svg
+++ b/src/lib/components/icons/blocks/svg/Interface.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="48" y1="12" x2="48" y2="52" stroke-dasharray="4 3"/>
+  <path d="M 24 22 L 42 22 M 36 16 L 42 22 L 36 28"/>
+  <path d="M 54 42 L 72 42 M 66 36 L 72 42 L 66 48"/>
+</svg>

--- a/src/lib/components/icons/blocks/svg/LessThan.svg
+++ b/src/lib/components/icons/blocks/svg/LessThan.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M 60 17 L 34 32 L 60 47"/>
+</svg>

--- a/src/lib/components/icons/blocks/svg/LogicAnd.svg
+++ b/src/lib/components/icons/blocks/svg/LogicAnd.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M14 14 H 32 A 18 18 0 0 1 32 50 H 14 Z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M 34 14 H 48 A 18 18 0 0 1 48 50 H 34 Z"/>
 </svg>

--- a/src/lib/components/icons/blocks/svg/LogicNot.svg
+++ b/src/lib/components/icons/blocks/svg/LogicNot.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <polygon points="14,14 14,50 46,32"/>
-  <circle cx="50" cy="32" r="4"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <polygon points="30,14 30,50 58,32"/>
+  <circle cx="62" cy="32" r="4"/>
 </svg>

--- a/src/lib/components/icons/blocks/svg/LogicOr.svg
+++ b/src/lib/components/icons/blocks/svg/LogicOr.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 14 Q 24 32, 12 50 Q 32 50, 50 32 Q 32 14, 12 14 Z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M 30 14 Q 41 32 30 50 Q 54 50 66 32 Q 54 14 30 14 Z"/>
 </svg>

--- a/src/lib/components/icons/blocks/svg/Multiplier.svg
+++ b/src/lib/components/icons/blocks/svg/Multiplier.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M 36 50 L 36 16 M 60 50 L 60 16 M 32 16 L 64 16"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M 36 50 L 36 14 M 60 50 L 60 14 M 31 14 L 65 14"/>
 </svg>

--- a/src/lib/components/icons/blocks/svg/Subsystem.svg
+++ b/src/lib/components/icons/blocks/svg/Subsystem.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
   <rect x="6" y="8" width="84" height="48" rx="3" stroke-dasharray="4 3"/>
   <rect x="14" y="20" width="18" height="10" rx="1.5"/>
   <rect x="39" y="34" width="18" height="10" rx="1.5"/>

--- a/src/lib/components/icons/blocks/svg/Switch.svg
+++ b/src/lib/components/icons/blocks/svg/Switch.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
   <line x1="22" y1="22" x2="40" y2="22"/>
   <line x1="22" y1="42" x2="40" y2="42"/>
   <line x1="56" y1="32" x2="74" y2="32"/>

--- a/src/lib/components/icons/blocks/svg/TappedDelay.svg
+++ b/src/lib/components/icons/blocks/svg/TappedDelay.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
   <line x1="10" y1="56" x2="88" y2="56"/>
   <line x1="12" y1="8" x2="12" y2="58"/>
   <path d="M 16 18 L 22 18 L 22 13 L 32 13 L 32 18 L 80 18"/>

--- a/src/lib/components/icons/blocks/svg/Wrapper.svg
+++ b/src/lib/components/icons/blocks/svg/Wrapper.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 64" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="22" y="12" width="52" height="40" rx="4" stroke-dasharray="4 3"/>
+  <rect x="36" y="24" width="24" height="16" rx="2"/>
+</svg>

--- a/src/routes/icons/+page.svelte
+++ b/src/routes/icons/+page.svelte
@@ -1,0 +1,290 @@
+<!--
+	Block icon gallery (dev/design aid).
+
+	Renders every registered block twice: once at true canvas scale (80×40 node)
+	and once enlarged, so icon legibility at real size can be judged directly.
+	Blocks without a registry entry are listed explicitly.
+-->
+<script lang="ts">
+	import { nodeRegistry } from '$lib/nodes/registry';
+	import BlockIcon, { hasBlockIcon } from '$lib/components/icons/BlockIcon.svelte';
+	import { getIconDef } from '$lib/components/icons/blocks/registry';
+	import { getKatexCssUrl } from '$lib/utils/katexLoader';
+
+	let theme = $state<'dark' | 'light'>('dark');
+	let showMissingOnly = $state(false);
+
+	$effect(() => {
+		document.documentElement.setAttribute('data-theme', theme);
+	});
+
+	const defs = nodeRegistry.getAll();
+
+	const byCategory = $derived.by(() => {
+		const map = new Map<string, typeof defs>();
+		for (const d of defs) {
+			if (showMissingOnly && hasBlockIcon(d.blockClass)) continue;
+			const list = map.get(d.category) ?? [];
+			list.push(d);
+			map.set(d.category, list);
+		}
+		for (const list of map.values()) list.sort((a, b) => a.name.localeCompare(b.name));
+		return Array.from(map.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+	});
+
+	const stats = $derived.by(() => {
+		const total = defs.length;
+		const withIcon = defs.filter((d) => hasBlockIcon(d.blockClass)).length;
+		const kinds = new Map<string, number>();
+		for (const d of defs) {
+			const k = getIconDef(d.blockClass)?.kind;
+			if (k) kinds.set(k, (kinds.get(k) ?? 0) + 1);
+		}
+		return { total, withIcon, missing: total - withIcon, kinds: Array.from(kinds.entries()) };
+	});
+</script>
+
+<svelte:head>
+	<title>Block Icon Gallery</title>
+	<link rel="stylesheet" href={getKatexCssUrl()} />
+</svelte:head>
+
+<div class="page">
+	<header>
+		<h1>Block Icon Gallery</h1>
+		<div class="stats">
+			<span>{stats.withIcon}/{stats.total} mit Icon</span>
+			<span class="missing-count">{stats.missing} ohne</span>
+			{#each stats.kinds as [kind, n]}<span class="kind">{kind}: {n}</span>{/each}
+		</div>
+		<div class="controls">
+			<button onclick={() => (theme = theme === 'dark' ? 'light' : 'dark')}>
+				{theme === 'dark' ? '☾ dark' : '☀ light'}
+			</button>
+			<label><input type="checkbox" bind:checked={showMissingOnly} /> nur fehlende</label>
+		</div>
+	</header>
+
+	{#each byCategory as [category, list]}
+		<section>
+			<h2>{category} <span class="n">({list.length})</span></h2>
+			<div class="grid">
+				{#each list as def}
+					{@const has = hasBlockIcon(def.blockClass)}
+					{@const kind = getIconDef(def.blockClass)?.kind}
+					<div class="cell" class:no-icon={!has}>
+						<div class="big">
+							{#if has}
+								<BlockIcon blockClass={def.blockClass} />
+							{:else}
+								<span class="dash">—</span>
+							{/if}
+						</div>
+						<div class="node-row">
+							<!-- true canvas scale: 80×40 block -->
+							<div class="node">
+								<span class="node-name">{def.name}</span>
+								{#if has}
+									<div class="node-icon"><BlockIcon blockClass={def.blockClass} /></div>
+								{:else}
+									<span class="node-type">{def.name}</span>
+								{/if}
+							</div>
+						</div>
+						<div class="label">
+							<span class="name">{def.name}</span>
+							{#if kind}<span class="badge">{kind}</span>{/if}
+						</div>
+					</div>
+				{/each}
+			</div>
+		</section>
+	{/each}
+</div>
+
+<style>
+	/* The app shell (+layout) is a fixed-height flex column with overflow
+	 * hidden, so this page has to be its own scroll container. */
+	.page {
+		flex: 1;
+		min-height: 0;
+		overflow-y: auto;
+		padding: 24px 32px 80px;
+		background: var(--surface);
+		color: var(--text);
+		font-family: var(--font-ui);
+	}
+
+	header {
+		display: flex;
+		align-items: center;
+		gap: 20px;
+		flex-wrap: wrap;
+		position: sticky;
+		top: 0;
+		background: var(--surface);
+		padding: 12px 0;
+		border-bottom: 1px solid var(--border);
+		z-index: 10;
+	}
+
+	h1 {
+		font-size: 16px;
+		font-weight: 600;
+		margin: 0;
+	}
+
+	.stats {
+		display: flex;
+		gap: 12px;
+		font-size: 12px;
+		color: var(--text-muted);
+	}
+
+	.missing-count {
+		color: var(--error);
+	}
+
+	.kind {
+		font-family: var(--font-mono);
+	}
+
+	.controls {
+		margin-left: auto;
+		display: flex;
+		gap: 12px;
+		align-items: center;
+		font-size: 12px;
+		color: var(--text-muted);
+	}
+
+	.controls button {
+		background: var(--surface-raised);
+		border: 1px solid var(--border);
+		color: var(--text);
+		border-radius: 6px;
+		padding: 4px 10px;
+		font-size: 12px;
+		cursor: pointer;
+	}
+
+	h2 {
+		font-size: 12px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--text-muted);
+		margin: 32px 0 12px;
+	}
+
+	.n {
+		font-weight: 400;
+		text-transform: none;
+	}
+
+	.grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+		gap: 12px;
+	}
+
+	.cell {
+		background: var(--surface-raised);
+		border: 1px solid var(--border);
+		border-radius: 8px;
+		padding: 10px;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.cell.no-icon {
+		border-color: color-mix(in srgb, var(--error) 45%, transparent);
+		background: var(--error-bg);
+	}
+
+	.big {
+		width: 120px;
+		height: 80px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--accent);
+	}
+
+	.dash {
+		color: var(--error);
+		font-size: 20px;
+	}
+
+	.node-row {
+		display: flex;
+		justify-content: center;
+	}
+
+	/* Mirrors BaseNode geometry at 1:1 canvas scale */
+	.node {
+		width: 80px;
+		height: 40px;
+		border: 1px solid var(--accent);
+		border-radius: 6px;
+		background: var(--surface-raised);
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		padding: 2px 4px 4px;
+		overflow: hidden;
+	}
+
+	.node-name {
+		font-size: 9px;
+		font-weight: 500;
+		line-height: 1.2;
+		color: var(--text);
+	}
+
+	.node-icon {
+		flex: 1;
+		min-height: 0;
+		margin-top: 1px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--accent);
+		width: 100%;
+	}
+
+	.node-icon :global(svg) {
+		width: 100%;
+		height: 100%;
+		display: block;
+	}
+
+	.node-type {
+		font-size: 8px;
+		color: var(--text-muted);
+	}
+
+	.label {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2px;
+	}
+
+	.name {
+		font-size: 11px;
+		font-family: var(--font-mono);
+		color: var(--text);
+		text-align: center;
+		word-break: break-word;
+	}
+
+	.badge {
+		font-size: 9px;
+		font-family: var(--font-mono);
+		color: var(--text-muted);
+		text-transform: uppercase;
+	}
+</style>


### PR DESCRIPTION
Adds icons for the 8 blocks that had none (Alias, Atan2, Divider, Wrapper, Equal, GreaterThan, LessThan, Interface) — all 80 blocks are now covered.

Unifies icon geometry: centred plot box on a shared 96x64 grid, symmetric axis overshoot, consistent stroke weight. The three logic gates were on a 64x64 grid and rendered ~50% oversized.

Distinguishes icons that were indistinguishable: ADC/DAC as a sampling/holding pair, TransferFunctionZPG as a pole-zero map, RandomNumberGenerator as discrete stems, Log10 by its base, AntiWindupPID by its saturating response.

Fixes: CounterDown drew a rising staircase, and SquareWave/TriangleWave/Mod ended mid-period.

Reworks Scope (graticule, decaying oscillation) and Spectrum (real bars), shortens the math icons to one line so they stay legible at block size, and adds a gallery route at /icons for reviewing all icons at real and enlarged scale.