### PR TITLE
Fix Chromium scroll jumping in block library (#329)

### DIFF
--- a/src/lib/components/panels/NodeLibrary.svelte
+++ b/src/lib/components/panels/NodeLibrary.svelte
@@ -346,6 +346,10 @@
 	.node-grid-container {
 		flex: 1;
 		overflow-y: auto;
+		/* Chromium scroll anchoring miscalculates the hover-driven layout
+		   changes (tile translateY, detail panel) and jumps the scroll
+		   position, see issue #329 */
+		overflow-anchor: none;
 		min-height: 0;
 		padding: var(--space-md);
 		background: var(--surface);

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -1572,7 +1572,6 @@
 			{#snippet footer()}
 				<div class="library-footer">
 					<span>Click or drag to add</span>
-					<span>â†‘â†“ Enter</span>
 				</div>
 			{/snippet}
 			<NodeLibrary


### PR DESCRIPTION
Fixes #329.

Chromium's scroll anchoring miscalculates the hover-driven layout changes in the block library (tile translateY, hover detail panel) and abruptly jumps the scroll position. Adds `overflow-anchor: none` to the scroll container `.node-grid-container` in `NodeLibrary.svelte`. Firefox is unaffected either way since it handled the layout correctly before.

Also removes the garbled keyboard hint (mojibake "â†‘â†“ Enter") from the block library footer.